### PR TITLE
Fix typo and update social media links

### DIFF
--- a/about.html
+++ b/about.html
@@ -448,7 +448,7 @@
           <div class="col-lg-5">
             <div class="card shadow">
               <div class="mx-5 my-3">
-                <form method="POST" action="https://formspree.io/hello@codeconnector_.com">
+                <form method="POST" action="https://formspree.io/hello@codeconnective.com">
                   <input type="hidden" name="_subject" value="Home submission">
                   <input type="text" name="_gotcha" style="display:none">
                   <div class="form-group row align-items-center">

--- a/about.html
+++ b/about.html
@@ -20,7 +20,7 @@
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
 		<meta name="twitter:image" content="content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@codeconnective">
+    <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
 		<link rel="shortcut icon" href="content/favicon.ico">
@@ -448,7 +448,7 @@
           <div class="col-lg-5">
             <div class="card shadow">
               <div class="mx-5 my-3">
-                <form method="POST" action="https://formspree.io/hello@codeconnective.com">
+                <form method="POST" action="https://formspree.io/hello@codeconnector_.com">
                   <input type="hidden" name="_subject" value="Home submission">
                   <input type="text" name="_gotcha" style="display:none">
                   <div class="form-group row align-items-center">

--- a/about.html
+++ b/about.html
@@ -498,7 +498,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.twitter.com/codeconnective" target="blank">
+                <a href="https://twitter.com/codeconnector_" target="blank">
                   <i class="fab fa-twitter"></i>
                 </a>
               </li>

--- a/about.html
+++ b/about.html
@@ -493,7 +493,7 @@
           <div class="col-md-6">
             <ul class="list-inline social-buttons">
               <li class="list-inline-item">
-                <a href="https://www.facebook.com/codeconnective" target="blank">
+                <a href="https://www.facebook.com/codeconnector" target="blank">
                   <i class="fab fa-facebook-f"></i>
                 </a>
               </li>

--- a/about.html
+++ b/about.html
@@ -508,7 +508,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.eventbrite.com/o/code-connective-15650145492" target="blank">
+                <a href="https://www.eventbrite.com/o/code-connector-15650145492" target="blank">
                   <i class="fas fa-calendar-alt"></i>
                 </a>
               </li>

--- a/assistance.html
+++ b/assistance.html
@@ -321,7 +321,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.eventbrite.com/o/code-connective-15650145492" target="blank">
+                <a href="https://www.eventbrite.com/o/code-connector-15650145492" target="blank">
                   <i class="fas fa-calendar-alt"></i>
                 </a>
               </li>

--- a/assistance.html
+++ b/assistance.html
@@ -306,7 +306,7 @@
           <div class="col-md-6">
             <ul class="list-inline social-buttons">
               <li class="list-inline-item">
-                <a href="https://www.facebook.com/codeconnective" target="blank">
+                <a href="https://www.facebook.com/codeconnector" target="blank">
                   <i class="fab fa-facebook-f"></i>
                 </a>
               </li>

--- a/assistance.html
+++ b/assistance.html
@@ -311,7 +311,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.twitter.com/codeconnective" target="blank">
+                <a href="https://twitter.com/codeconnector_" target="blank">
                   <i class="fab fa-twitter"></i>
                 </a>
               </li>

--- a/assistance.html
+++ b/assistance.html
@@ -20,7 +20,7 @@
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
 		<meta name="twitter:image" content="content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@codeconnective">
+    <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
 		<link rel="shortcut icon" href="content/favicon.ico">

--- a/birmingham.html
+++ b/birmingham.html
@@ -316,7 +316,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.eventbrite.com/o/code-connective-15650145492" target="blank">
+                <a href="https://www.eventbrite.com/o/code-connector-15650145492" target="blank">
                   <i class="fas fa-calendar-alt"></i>
                 </a>
               </li>

--- a/birmingham.html
+++ b/birmingham.html
@@ -306,7 +306,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.twitter.com/codeconnective" target="blank">
+                <a href="https://twitter.com/codeconnector_" target="blank">
                   <i class="fab fa-twitter"></i>
                 </a>
               </li>

--- a/birmingham.html
+++ b/birmingham.html
@@ -20,7 +20,7 @@
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
 		<meta name="twitter:image" content="content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@codeconnective">
+    <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
 		<link rel="shortcut icon" href="content/favicon.ico">

--- a/birmingham.html
+++ b/birmingham.html
@@ -301,7 +301,7 @@
           <div class="col-md-6">
             <ul class="list-inline social-buttons">
               <li class="list-inline-item">
-                <a href="https://www.facebook.com/codeconnective" target="blank">
+                <a href="https://www.facebook.com/codeconnector" target="blank">
                   <i class="fab fa-facebook-f"></i>
                 </a>
               </li>

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
 		<meta name="twitter:image" content="content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@codeconnective">
+    <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
 		<link rel="shortcut icon" href="content/favicon.ico">
@@ -331,7 +331,7 @@
           <div class="col-lg-5">
             <div class="card shadow">
               <div class="mx-5 my-3">
-                <form method="POST" action="https://formspree.io/hello@codeconnective.com">
+                <form method="POST" action="https://formspree.io/hello@codeconnector_.com">
                   <input type="hidden" name="_subject" value="Home submission">
                   <input type="text" name="_gotcha" style="display:none">
                   <div class="form-group row align-items-center">

--- a/index.html
+++ b/index.html
@@ -381,7 +381,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.twitter.com/codeconnective" target="blank">
+                <a href="https://twitter.com/codeconnector_" target="blank">
                   <i class="fab fa-twitter"></i>
                 </a>
               </li>

--- a/index.html
+++ b/index.html
@@ -391,7 +391,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.eventbrite.com/o/code-connective-15650145492" target="blank">
+                <a href="https://www.eventbrite.com/o/code-connector-15650145492" target="blank">
                   <i class="fas fa-calendar-alt"></i>
                 </a>
               </li>

--- a/index.html
+++ b/index.html
@@ -331,7 +331,7 @@
           <div class="col-lg-5">
             <div class="card shadow">
               <div class="mx-5 my-3">
-                <form method="POST" action="https://formspree.io/hello@codeconnector_.com">
+                <form method="POST" action="https://formspree.io/hello@codeconnective.com">
                   <input type="hidden" name="_subject" value="Home submission">
                   <input type="text" name="_gotcha" style="display:none">
                   <div class="form-group row align-items-center">

--- a/index.html
+++ b/index.html
@@ -376,7 +376,7 @@
           <div class="col-md-6">
             <ul class="list-inline social-buttons">
               <li class="list-inline-item">
-                <a href="https://www.facebook.com/codeconnective" target="blank">
+                <a href="https://www.facebook.com/codeconnector" target="blank">
                   <i class="fab fa-facebook-f"></i>
                 </a>
               </li>

--- a/knoxville.html
+++ b/knoxville.html
@@ -358,7 +358,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.eventbrite.com/o/code-connective-15650145492" target="blank">
+                <a href="https://www.eventbrite.com/o/code-connector-15650145492" target="blank">
                   <i class="fas fa-calendar-alt"></i>
                 </a>
               </li>

--- a/knoxville.html
+++ b/knoxville.html
@@ -348,7 +348,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.twitter.com/codeconnective" target="blank">
+                <a href="https://twitter.com/codeconnector_" target="blank">
                   <i class="fab fa-twitter"></i>
                 </a>
               </li>

--- a/knoxville.html
+++ b/knoxville.html
@@ -343,7 +343,7 @@
           <div class="col-md-6">
             <ul class="list-inline social-buttons">
               <li class="list-inline-item">
-                <a href="https://www.facebook.com/codeconnective" target="blank">
+                <a href="https://www.facebook.com/codeconnector" target="blank">
                   <i class="fab fa-facebook-f"></i>
                 </a>
               </li>

--- a/knoxville.html
+++ b/knoxville.html
@@ -20,7 +20,7 @@
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
 		<meta name="twitter:image" content="content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@codeconnective">
+    <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
 		<link rel="shortcut icon" href="content/favicon.ico">

--- a/learn.html
+++ b/learn.html
@@ -425,7 +425,7 @@
           <div class="col-md-6">
             <ul class="list-inline social-buttons">
               <li class="list-inline-item">
-                <a href="https://www.facebook.com/codeconnective" target="blank">
+                <a href="https://www.facebook.com/codeconnector" target="blank">
                   <i class="fab fa-facebook-f"></i>
                 </a>
               </li>

--- a/learn.html
+++ b/learn.html
@@ -380,7 +380,7 @@
           <div class="col-lg-5">
             <div class="card shadow">
               <div class="mx-5 my-3">
-                <form method="POST" action="https://formspree.io/hello@codeconnector_.com">
+                <form method="POST" action="https://formspree.io/hello@codeconnective.com">
                   <input type="hidden" name="_subject" value="Home submission">
                   <input type="text" name="_gotcha" style="display:none">
                   <div class="form-group row align-items-center">

--- a/learn.html
+++ b/learn.html
@@ -430,7 +430,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.twitter.com/codeconnective" target="blank">
+                <a href="https://twitter.com/codeconnector_" target="blank">
                   <i class="fab fa-twitter"></i>
                 </a>
               </li>

--- a/learn.html
+++ b/learn.html
@@ -286,7 +286,7 @@
                     <a class="btn btn-primary" href="http://www.facebook.com/codeconnective/events" target="_blank">Facebook</a>
                   </div>
                   <div class="col-sm-6 text-md-left">
-                    <a class="btn btn-primary" href="https://www.eventbrite.com/o/code-connective-15650145492" target="_blank">Eventbrite</a>
+                    <a class="btn btn-primary" href="https://www.eventbrite.com/o/code-connector-15650145492" target="_blank">Eventbrite</a>
                   </div>
                 </div>
               </div>
@@ -440,7 +440,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.eventbrite.com/o/code-connective-15650145492" target="blank">
+                <a href="https://www.eventbrite.com/o/code-connector-15650145492" target="blank">
                   <i class="fas fa-calendar-alt"></i>
                 </a>
               </li>

--- a/learn.html
+++ b/learn.html
@@ -20,7 +20,7 @@
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
 		<meta name="twitter:image" content="content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@codeconnective">
+    <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
 		<link rel="shortcut icon" href="content/favicon.ico">
@@ -380,7 +380,7 @@
           <div class="col-lg-5">
             <div class="card shadow">
               <div class="mx-5 my-3">
-                <form method="POST" action="https://formspree.io/hello@codeconnective.com">
+                <form method="POST" action="https://formspree.io/hello@codeconnector_.com">
                   <input type="hidden" name="_subject" value="Home submission">
                   <input type="text" name="_gotcha" style="display:none">
                   <div class="form-group row align-items-center">

--- a/memphis.html
+++ b/memphis.html
@@ -396,7 +396,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.eventbrite.com/o/code-connective-15650145492" target="blank">
+                <a href="https://www.eventbrite.com/o/code-connector-15650145492" target="blank">
                   <i class="fas fa-calendar-alt"></i>
                 </a>
               </li>

--- a/memphis.html
+++ b/memphis.html
@@ -20,7 +20,7 @@
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
 		<meta name="twitter:image" content="content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@codeconnective">
+    <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
 		<link rel="shortcut icon" href="content/favicon.ico">

--- a/memphis.html
+++ b/memphis.html
@@ -381,7 +381,7 @@
           <div class="col-md-6">
             <ul class="list-inline social-buttons">
               <li class="list-inline-item">
-                <a href="https://www.facebook.com/codeconnective" target="blank">
+                <a href="https://www.facebook.com/codeconnector" target="blank">
                   <i class="fab fa-facebook-f"></i>
                 </a>
               </li>

--- a/memphis.html
+++ b/memphis.html
@@ -386,7 +386,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.twitter.com/codeconnective" target="blank">
+                <a href="https://twitter.com/codeconnector_" target="blank">
                   <i class="fab fa-twitter"></i>
                 </a>
               </li>

--- a/montgomery.html
+++ b/montgomery.html
@@ -335,7 +335,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.eventbrite.com/o/code-connective-15650145492" target="blank">
+                <a href="https://www.eventbrite.com/o/code-connector-15650145492" target="blank">
                   <i class="fas fa-calendar-alt"></i>
                 </a>
               </li>

--- a/montgomery.html
+++ b/montgomery.html
@@ -320,7 +320,7 @@
           <div class="col-md-6">
             <ul class="list-inline social-buttons">
               <li class="list-inline-item">
-                <a href="https://www.facebook.com/codeconnective" target="blank">
+                <a href="https://www.facebook.com/codeconnector" target="blank">
                   <i class="fab fa-facebook-f"></i>
                 </a>
               </li>

--- a/montgomery.html
+++ b/montgomery.html
@@ -20,7 +20,7 @@
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
 		<meta name="twitter:image" content="content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@codeconnective">
+    <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
 		<link rel="shortcut icon" href="content/favicon.ico">

--- a/montgomery.html
+++ b/montgomery.html
@@ -325,7 +325,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.twitter.com/codeconnective" target="blank">
+                <a href="https://twitter.com/codeconnector_" target="blank">
                   <i class="fab fa-twitter"></i>
                 </a>
               </li>

--- a/northmississippi.html
+++ b/northmississippi.html
@@ -363,7 +363,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.eventbrite.com/o/code-connective-15650145492" target="blank">
+                <a href="https://www.eventbrite.com/o/code-connector-15650145492" target="blank">
                   <i class="fas fa-calendar-alt"></i>
                 </a>
               </li>

--- a/northmississippi.html
+++ b/northmississippi.html
@@ -20,7 +20,7 @@
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
 		<meta name="twitter:image" content="content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@codeconnective">
+    <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
 		<link rel="shortcut icon" href="content/favicon.ico">

--- a/northmississippi.html
+++ b/northmississippi.html
@@ -348,7 +348,7 @@
           <div class="col-md-6">
             <ul class="list-inline social-buttons">
               <li class="list-inline-item">
-                <a href="https://www.facebook.com/codeconnective" target="blank">
+                <a href="https://www.facebook.com/codeconnector" target="blank">
                   <i class="fab fa-facebook-f"></i>
                 </a>
               </li>

--- a/northmississippi.html
+++ b/northmississippi.html
@@ -353,7 +353,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.twitter.com/codeconnective" target="blank">
+                <a href="https://twitter.com/codeconnector_" target="blank">
                   <i class="fab fa-twitter"></i>
                 </a>
               </li>

--- a/slack.html
+++ b/slack.html
@@ -240,7 +240,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.twitter.com/codeconnective" target="blank">
+                <a href="https://twitter.com/codeconnector_" target="blank">
                   <i class="fab fa-twitter"></i>
                 </a>
               </li>

--- a/slack.html
+++ b/slack.html
@@ -20,7 +20,7 @@
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
 		<meta name="twitter:image" content="content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@codeconnective">
+    <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
 		<link rel="shortcut icon" href="content/favicon.ico">
@@ -190,7 +190,7 @@
           <div class="col-lg-5">
             <div class="card shadow">
               <div class="mx-5 my-3">
-                <form method="POST" action="https://formspree.io/hello@codeconnective.com">
+                <form method="POST" action="https://formspree.io/hello@codeconnector_.com">
                   <input type="hidden" name="_subject" value="Home submission">
                   <input type="text" name="_gotcha" style="display:none">
                   <div class="form-group row align-items-center">

--- a/slack.html
+++ b/slack.html
@@ -250,7 +250,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.eventbrite.com/o/code-connective-15650145492" target="blank">
+                <a href="https://www.eventbrite.com/o/code-connector-15650145492" target="blank">
                   <i class="fas fa-calendar-alt"></i>
                 </a>
               </li>

--- a/slack.html
+++ b/slack.html
@@ -190,7 +190,7 @@
           <div class="col-lg-5">
             <div class="card shadow">
               <div class="mx-5 my-3">
-                <form method="POST" action="https://formspree.io/hello@codeconnector_.com">
+                <form method="POST" action="https://formspree.io/hello@codeconnective.com">
                   <input type="hidden" name="_subject" value="Home submission">
                   <input type="text" name="_gotcha" style="display:none">
                   <div class="form-group row align-items-center">

--- a/slack.html
+++ b/slack.html
@@ -235,7 +235,7 @@
           <div class="col-md-6">
             <ul class="list-inline social-buttons">
               <li class="list-inline-item">
-                <a href="https://www.facebook.com/codeconnective" target="blank">
+                <a href="https://www.facebook.com/codeconnector" target="blank">
                   <i class="fab fa-facebook-f"></i>
                 </a>
               </li>

--- a/sponsor.html
+++ b/sponsor.html
@@ -388,7 +388,7 @@
           <div class="col-md-6">
             <ul class="list-inline social-buttons">
               <li class="list-inline-item">
-                <a href="https://www.facebook.com/codeconnective" target="blank">
+                <a href="https://www.facebook.com/codeconnector" target="blank">
                   <i class="fab fa-facebook-f"></i>
                 </a>
               </li>

--- a/sponsor.html
+++ b/sponsor.html
@@ -393,7 +393,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.twitter.com/codeconnective" target="blank">
+                <a href="https://twitter.com/codeconnector_" target="blank">
                   <i class="fab fa-twitter"></i>
                 </a>
               </li>

--- a/sponsor.html
+++ b/sponsor.html
@@ -403,7 +403,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.eventbrite.com/o/code-connective-15650145492" target="blank">
+                <a href="https://www.eventbrite.com/o/code-connector-15650145492" target="blank">
                   <i class="fas fa-calendar-alt"></i>
                 </a>
               </li>

--- a/sponsor.html
+++ b/sponsor.html
@@ -236,7 +236,7 @@
               In addition to giving contributors the credit they deserve, we want to take this one step further by offering up the chance to engage with the potential hires, clients, and students in your community.
             </p>
             <p class="text-muted">
-              If you or one of your teammates are present at out meetup, we'll set you up with the opportunity to make genuine connections with eager folks in your community.
+              If you or one of your teammates are present at our meetup, we'll set you up with the opportunity to make genuine connections with eager folks in your community.
             </p>
           </div>
         </div>

--- a/sponsor.html
+++ b/sponsor.html
@@ -20,7 +20,7 @@
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
 		<meta name="twitter:image" content="content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@codeconnective">
+    <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
 		<link rel="shortcut icon" href="content/favicon.ico">

--- a/start.html
+++ b/start.html
@@ -589,7 +589,7 @@
           <div class="col-md-6">
             <ul class="list-inline social-buttons">
               <li class="list-inline-item">
-                <a href="https://www.facebook.com/codeconnective" target="blank">
+                <a href="https://www.facebook.com/codeconnector" target="blank">
                   <i class="fab fa-facebook-f"></i>
                 </a>
               </li>

--- a/start.html
+++ b/start.html
@@ -604,7 +604,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.eventbrite.com/o/code-connective-15650145492" target="blank">
+                <a href="https://www.eventbrite.com/o/code-connector-15650145492" target="blank">
                   <i class="fas fa-calendar-alt"></i>
                 </a>
               </li>

--- a/start.html
+++ b/start.html
@@ -594,7 +594,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.twitter.com/codeconnective" target="blank">
+                <a href="https://twitter.com/codeconnector_" target="blank">
                   <i class="fab fa-twitter"></i>
                 </a>
               </li>

--- a/start.html
+++ b/start.html
@@ -20,7 +20,7 @@
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
 		<meta name="twitter:image" content="content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@codeconnective">
+    <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
 		<link rel="shortcut icon" href="content/favicon.ico">

--- a/thankyou.html
+++ b/thankyou.html
@@ -20,7 +20,7 @@
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
 		<meta name="twitter:image" content="content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@codeconnective">
+    <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
 		<link rel="shortcut icon" href="content/favicon.ico">

--- a/volunteer.html
+++ b/volunteer.html
@@ -296,7 +296,7 @@
           <div class="col-md-6">
             <ul class="list-inline social-buttons">
               <li class="list-inline-item">
-                <a href="https://www.facebook.com/codeconnective" target="blank">
+                <a href="https://www.facebook.com/codeconnector" target="blank">
                   <i class="fab fa-facebook-f"></i>
                 </a>
               </li>

--- a/volunteer.html
+++ b/volunteer.html
@@ -311,7 +311,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.eventbrite.com/o/code-connective-15650145492" target="blank">
+                <a href="https://www.eventbrite.com/o/code-connector-15650145492" target="blank">
                   <i class="fas fa-calendar-alt"></i>
                 </a>
               </li>

--- a/volunteer.html
+++ b/volunteer.html
@@ -301,7 +301,7 @@
                 </a>
               </li>
               <li class="list-inline-item">
-                <a href="https://www.twitter.com/codeconnective" target="blank">
+                <a href="https://twitter.com/codeconnector_" target="blank">
                   <i class="fab fa-twitter"></i>
                 </a>
               </li>

--- a/volunteer.html
+++ b/volunteer.html
@@ -20,7 +20,7 @@
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
 		<meta name="twitter:image" content="content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:site" content="@codeconnective">
+    <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
 		<link rel="shortcut icon" href="content/favicon.ico">


### PR DESCRIPTION
- Fixes a typo on the Sponsor page
- Updates the social media links from the Code Connective to Code Connector (Facebook, Twitter link, Twitter handle, Eventbrite). Did not change LinkedIn because the link is still the same.