### PR TITLE
Added data-target="#" to all navbar links

### DIFF
--- a/about.html
+++ b/about.html
@@ -53,7 +53,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
       <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html">Code Connector</a>
+        <a class="navbar-brand js-scroll-trigger" href="#page-top">Code Connector</a>
         <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="d-none d-md-inline">Menu</span><span class="d-inline d-md-none"><i class="fas fa-bars"></i></span>
         </button>
@@ -65,18 +65,18 @@
             </li>
             -->
             <li class="nav-item">
-              <a class="nav-link" href="learn.html">Learn</a>
+              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html">North Mississippi</a>
+                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -86,13 +86,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html">Receive meetup assistance</a>
+                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link active" href="about.html">About</a>
+              <a class="nav-link" href="about.html" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>

--- a/assistance.html
+++ b/assistance.html
@@ -52,7 +52,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
       <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html">Code Connector</a>
+        <a class="navbar-brand js-scroll-trigger" href="#page-top">Code Connector</a>
         <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="d-none d-md-inline">Menu</span><span class="d-inline d-md-none"><i class="fas fa-bars"></i></span>
         </button>
@@ -64,34 +64,34 @@
             </li>
             -->
             <li class="nav-item">
-              <a class="nav-link" href="learn.html">Learn</a>
+              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html">North Mississippi</a>
+                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
             </li>
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle active" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html">Through sponsorship</a>
-                <a class="dropdown-item text-muted" href="assistance.html">Receive meetup assistance</a>
+                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html">About</a>
+              <a class="nav-link" href="about.html" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>

--- a/birmingham.html
+++ b/birmingham.html
@@ -53,7 +53,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
       <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html">Code Connector</a>
+        <a class="navbar-brand js-scroll-trigger" href="#page-top">Code Connector</a>
         <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="d-none d-md-inline">Menu</span><span class="d-inline d-md-none"><i class="fas fa-bars"></i></span>
         </button>
@@ -65,18 +65,18 @@
             </li>
             -->
             <li class="nav-item">
-              <a class="nav-link" href="learn.html">Learn</a>
+              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle active" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html">Memphis</a>
-                <a class="dropdown-item text-muted" href="birmingham.html">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html">North Mississippi</a>
+                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -86,13 +86,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html">Receive meetup assistance</a>
+                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html">About</a>
+              <a class="nav-link" href="about.html" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>

--- a/index.html
+++ b/index.html
@@ -65,18 +65,18 @@
             </li>
             -->
             <li class="nav-item">
-              <a class="nav-link" href="learn.html">Learn</a>
+              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html">North Mississippi</a>
+                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -86,13 +86,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html">Receive meetup assistance</a>
+                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html">About</a>
+              <a class="nav-link" href="about.html" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>

--- a/knoxville.html
+++ b/knoxville.html
@@ -53,7 +53,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
       <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html">Code Connector</a>
+        <a class="navbar-brand js-scroll-trigger" href="#page-top">Code Connector</a>
         <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="d-none d-md-inline">Menu</span><span class="d-inline d-md-none"><i class="fas fa-bars"></i></span>
         </button>
@@ -65,18 +65,18 @@
             </li>
             -->
             <li class="nav-item">
-              <a class="nav-link" href="learn.html">Learn</a>
+              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle active" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html">Birmingham</a>
-                <a class="dropdown-item text-muted" href="knoxville.html">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html">North Mississippi</a>
+                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -86,13 +86,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html">Receive meetup assistance</a>
+                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html">About</a>
+              <a class="nav-link" href="about.html" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>

--- a/learn.html
+++ b/learn.html
@@ -53,7 +53,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
       <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html">Code Connector</a>
+        <a class="navbar-brand js-scroll-trigger" href="#page-top">Code Connector</a>
         <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="d-none d-md-inline">Menu</span><span class="d-inline d-md-none"><i class="fas fa-bars"></i></span>
         </button>
@@ -65,18 +65,18 @@
             </li>
             -->
             <li class="nav-item">
-              <a class="nav-link active" href="learn.html">Learn</a>
+              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html">North Mississippi</a>
+                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -86,13 +86,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html">Receive meetup assistance</a>
+                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html">About</a>
+              <a class="nav-link" href="about.html" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>

--- a/memphis.html
+++ b/memphis.html
@@ -53,7 +53,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
       <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html">Code Connector</a>
+        <a class="navbar-brand js-scroll-trigger" href="#page-top">Code Connector</a>
         <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="d-none d-md-inline">Menu</span><span class="d-inline d-md-none"><i class="fas fa-bars"></i></span>
         </button>
@@ -65,18 +65,18 @@
             </li>
             -->
             <li class="nav-item">
-              <a class="nav-link" href="learn.html">Learn</a>
+              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle active" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item text-muted" href="memphis.html">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html">North Mississippi</a>
+                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -86,13 +86,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html">Receive meetup assistance</a>
+                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html">About</a>
+              <a class="nav-link" href="about.html" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>

--- a/montgomery.html
+++ b/montgomery.html
@@ -53,7 +53,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
       <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html">Code Connector</a>
+        <a class="navbar-brand js-scroll-trigger" href="#page-top">Code Connector</a>
         <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="d-none d-md-inline">Menu</span><span class="d-inline d-md-none"><i class="fas fa-bars"></i></span>
         </button>
@@ -65,18 +65,18 @@
             </li>
             -->
             <li class="nav-item">
-              <a class="nav-link" href="learn.html">Learn</a>
+              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle active" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html">Knoxville</a>
-                <a class="dropdown-item text-muted" href="montgomery.html">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html">North Mississippi</a>
+                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -86,13 +86,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html">Receive meetup assistance</a>
+                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html">About</a>
+              <a class="nav-link" href="about.html" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>

--- a/northmississippi.html
+++ b/northmississippi.html
@@ -53,7 +53,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
       <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html">Code Connector</a>
+        <a class="navbar-brand js-scroll-trigger" href="#page-top">Code Connector</a>
         <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="d-none d-md-inline">Menu</span><span class="d-inline d-md-none"><i class="fas fa-bars"></i></span>
         </button>
@@ -65,18 +65,18 @@
             </li>
             -->
             <li class="nav-item">
-              <a class="nav-link" href="learn.html">Learn</a>
+              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle active" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html">Montgomery</a>
-                <a class="dropdown-item text-muted" href="northmississippi.html">North Mississippi</a>
+                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -86,13 +86,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html">Receive meetup assistance</a>
+                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html">About</a>
+              <a class="nav-link" href="about.html" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>

--- a/slack.html
+++ b/slack.html
@@ -53,7 +53,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
       <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html">Code Connector</a>
+        <a class="navbar-brand js-scroll-trigger" href="#page-top">Code Connector</a>
         <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="d-none d-md-inline">Menu</span><span class="d-inline d-md-none"><i class="fas fa-bars"></i></span>
         </button>
@@ -65,18 +65,18 @@
             </li>
             -->
             <li class="nav-item">
-              <a class="nav-link" href="learn.html">Learn</a>
+              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html">North Mississippi</a>
+                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -86,13 +86,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html">Receive meetup assistance</a>
+                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html">About</a>
+              <a class="nav-link" href="about.html" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>

--- a/sponsor.html
+++ b/sponsor.html
@@ -53,7 +53,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
       <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html">Code Connector</a>
+        <a class="navbar-brand js-scroll-trigger" href="#page-top">Code Connector</a>
         <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="d-none d-md-inline">Menu</span><span class="d-inline d-md-none"><i class="fas fa-bars"></i></span>
         </button>
@@ -65,34 +65,34 @@
             </li>
             -->
             <li class="nav-item">
-              <a class="nav-link" href="learn.html">Learn</a>
+              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html">North Mississippi</a>
+                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
             </li>
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle active" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html">Get involved</a>
-                <a class="dropdown-item text-muted" href="sponsor.html">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html">Receive meetup assistance</a>
+                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html">About</a>
+              <a class="nav-link" href="about.html" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>

--- a/start.html
+++ b/start.html
@@ -53,7 +53,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
       <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html">Code Connector</a>
+        <a class="navbar-brand js-scroll-trigger" href="#page-top">Code Connector</a>
         <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="d-none d-md-inline">Menu</span><span class="d-inline d-md-none"><i class="fas fa-bars"></i></span>
         </button>
@@ -65,20 +65,20 @@
             </li>
             -->
             <li class="nav-item">
-              <a class="nav-link" href="learn.html">Learn</a>
+              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html">North Mississippi</a>
+                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
-                <a class="dropdown-item" href="#">Start a meetup</a>
+                <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
             </li>
             <li class="nav-item dropdown">
@@ -86,13 +86,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html">Receive meetup assistance</a>
+                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html">About</a>
+              <a class="nav-link" href="about.html" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>

--- a/thankyou.html
+++ b/thankyou.html
@@ -65,18 +65,18 @@
             </li>
             -->
             <li class="nav-item">
-              <a class="nav-link" href="learn.html">Learn</a>
+              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html">North Mississippi</a>
+                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -86,13 +86,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html">Receive meetup assistance</a>
+                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html">About</a>
+              <a class="nav-link" href="about.html" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>

--- a/volunteer.html
+++ b/volunteer.html
@@ -53,7 +53,7 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
       <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html">Code Connector</a>
+        <a class="navbar-brand js-scroll-trigger" href="#page-top">Code Connector</a>
         <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation">
           <span class="d-none d-md-inline">Menu</span><span class="d-inline d-md-none"><i class="fas fa-bars"></i></span>
         </button>
@@ -65,34 +65,34 @@
             </li>
             -->
             <li class="nav-item">
-              <a class="nav-link" href="learn.html">Learn</a>
+              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html">North Mississippi</a>
+                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
             </li>
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle active" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item text-muted" href="volunteer.html">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html">Receive meetup assistance</a>
+                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html">About</a>
+              <a class="nav-link" href="about.html" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>


### PR DESCRIPTION
This is an attempt to fix a bug in which the navbar does not take a purple background when scrolling. Currently on the live site, we get the following behavior and console error message:

<img width="957" alt="CCnavbarbug" src="https://user-images.githubusercontent.com/42074868/60849685-11b30280-a1a9-11e9-80fe-45a29120723c.png">

Searching through bootstrap issues on Github, I found that this error message also can occur on bootstrap dropdowns, and a quick fix is to add a data-target="#" to links. [https://github.com/twbs/bootstrap/issues/27903#issuecomment-450292043](url)

I don't know if this will work or not, since the issue only appears on the live site. But I thought I'd at least give it a shot. 
