### PR TITLE
Fixup relative links to be root based

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,17 +13,17 @@
 
 		<meta property="og:title" content="Code Connector">
 		<meta property="og:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta property="og:image" content="content/link_preview.jpg">
+		<meta property="og:image" content="/content/link_preview.jpg">
 		<meta property="og:url" content="https://www.codeconnective.com">
 
 		<meta name="twitter:title" content="Code Connector">
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta name="twitter:image" content="content/link_preview.jpg">
+		<meta name="twitter:image" content="/content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
-		<link rel="shortcut icon" href="content/favicon.ico">
+		<link rel="shortcut icon" href="/content/favicon.ico">
 
     <title>About</title>
 
@@ -36,8 +36,8 @@
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,600,700,900" rel="stylesheet">
 
     <!-- Custom styles -->
-    <link href="css/core.css" rel="stylesheet">
-    <link href="css/secondary.css" rel="stylesheet">
+    <link href="/css/core.css" rel="stylesheet">
+    <link href="/css/secondary.css" rel="stylesheet">
 
   </head>
 
@@ -52,18 +52,18 @@
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
-              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
+              <a class="nav-link" href="/learn" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Memphis</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Birmingham</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Lehigh Valley</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Knoxville</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">North Mississippi</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Memphis</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Birmingham</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Lehigh Valley</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Knoxville</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -73,13 +73,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
+                <a class="dropdown-item" href="/volunteer" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="/sponsor" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="/assistance" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html" data-target="#">About</a>
+              <a class="nav-link" href="/about" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>
@@ -106,7 +106,7 @@
     <header>
       <div class="overlay"></div>
       <video playsinline="playsinline" autoplay="autoplay" muted="muted" loop="loop">
-        <source src="content/videos/talk2.mp4" type="video/mp4">
+        <source src="/content/videos/talk2.mp4" type="video/mp4">
       </video>
       <div class="container h-100">
         <div class="d-flex h-100 text-center align-items-center">
@@ -132,12 +132,12 @@
             <p class="text-muted pt-2">Whether through mentorship at one of our meetups or a conversation through our online chat community, we think people deserve free, no-strings-attached assistance.</p>
           </div>
           <div class="col-md-6 order-1 order-md-2">
-            <img src="content/images/meetups/color/5by7/14.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendee examining laptop with mentor">
+            <img src="/content/images/meetups/color/5by7/14.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendee examining laptop with mentor">
           </div>
         </div>
         <div class="row py-5 d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/20a.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees having a good time at two tables">
+            <img src="/content/images/meetups/color/5by7/20a.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees having a good time at two tables">
           </div>
           <div class="col-md-4 ml-md-4 text-center text-md-left">
             <h1 class="text-primary">Connect</h1>
@@ -150,7 +150,7 @@
             <p class="text-muted pt-2">It goes without saying, but it should be no surprise that our world and pockets of society have not always treated people fairly. No matter a person's gender, color, creed or situation, we want to empower the tech industry to serve and be led by all people.</p>
           </div>
           <div class="col-md-6 order-1 order-md-2">
-            <img src="content/images/meetups/color/5by7/8.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees standing for group photo">
+            <img src="/content/images/meetups/color/5by7/8.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees standing for group photo">
           </div>
         </div>
       </div>
@@ -168,7 +168,7 @@
         </div>
         <div class="row d-flex justify-content-center">
           <div class="col-md-6 col-lg-4 text-center px-5 pb-5">
-            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="content/images/team/stefan-hk.jpg" alt="Portrait of Stefan Hodges-Cluck">
+            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="/content/images/team/stefan-hk.jpg" alt="Portrait of Stefan Hodges-Cluck">
             <h5>Stefan Hodges-Kluck</h5>
             <p class="text-muted">Knoxville leader</p>
             <ul class="list-inline social-buttons">
@@ -191,7 +191,7 @@
           </div>
           <!--
           <div class="col-md-6 col-lg-4 text-center px-5 pb-5">
-            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="content/images/team/alan1.jpg" alt="">
+            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="/content/images/team/alan1.jpg" alt="">
             <h5>Alan Carpenter</h5>
             <p class="text-muted">Cookeville leader</p>
             <ul class="list-inline social-buttons">
@@ -204,7 +204,7 @@
           </div>
           -->
           <div class="col-md-6 col-lg-4 text-center px-5 pb-5">
-            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="content/images/team/lisa-b.jpg" alt="Portrait of Lisa Bamberg">
+            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="/content/images/team/lisa-b.jpg" alt="Portrait of Lisa Bamberg">
             <h5>Lisa Bamberg</h5>
             <p class="text-muted">Birmingham Leader</p>
             <ul class="list-inline social-buttons">
@@ -216,7 +216,7 @@
             </ul>
           </div>
           <div class="col-md-6 col-lg-4 text-center px-5 pb-5">
-            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="content/images/team/ray-r.jpg" alt="Portrait of Ray Randle">
+            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="/content/images/team/ray-r.jpg" alt="Portrait of Ray Randle">
             <h5>Ray Randle</h5>
             <p class="text-muted">Birmingham leader</p>
             <ul class="list-inline social-buttons">
@@ -228,7 +228,7 @@
             </ul>
           </div>
           <div class="col-md-6 col-lg-4 text-center px-5 pb-5">
-            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="content/images/team/chris-f.jpg" alt="Portrait of Chris Finney">
+            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="/content/images/team/chris-f.jpg" alt="Portrait of Chris Finney">
             <h5>Chris Finney</h5>
             <p class="text-muted">Birmingham leader</p>
             <ul class="list-inline social-buttons">
@@ -245,7 +245,7 @@
             </ul>
           </div>
           <div class="col-md-6 col-lg-4 text-center px-5 pb-5">
-            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="content/images/team/jacob-w.jpg" alt="Portrait of Jacob Watson">
+            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="/content/images/team/jacob-w.jpg" alt="Portrait of Jacob Watson">
             <h5>Jacob Watson</h5>
             <p class="text-muted">Birmingham Leader</p>
             <ul class="list-inline social-buttons">
@@ -257,7 +257,7 @@
             </ul>
           </div>
           <div class="col-md-6 col-lg-4 text-center px-5 pb-5">
-            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="content/images/team/stefan-f.jpg" alt="Portrait of Stefan Formentano">
+            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="/content/images/team/stefan-f.jpg" alt="Portrait of Stefan Formentano">
             <h5>Stefan Formentano</h5>
             <p class="text-muted">Birmingham Leader</p>
             <ul class="list-inline social-buttons">
@@ -269,7 +269,7 @@
             </ul>
           </div>
           <div class="col-md-6 col-lg-4 text-center px-5 pb-5">
-            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="content/images/team/jc-s.jpg" alt="Portrait of JC Smiley">
+            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="/content/images/team/jc-s.jpg" alt="Portrait of JC Smiley">
             <h5>JC Smiley</h5>
             <p class="text-muted">Community Manager /<br>Memphis leader</p>
             <ul class="list-inline social-buttons">
@@ -286,7 +286,7 @@
             </ul>
           </div>
           <div class="col-md-6 col-lg-4 text-center px-5 pb-5">
-            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="content/images/team/ryan-c.jpg" alt="Portrait of Ryan Clearly">
+            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="/content/images/team/ryan-c.jpg" alt="Portrait of Ryan Clearly">
             <h5>Ryan Clearly</h5>
             <p class="text-muted">Memphis Leader</p>
             <ul class="list-inline social-buttons">
@@ -298,7 +298,7 @@
             </ul>
           </div>
           <div class="col-md-6 col-lg-4 text-center px-5 pb-5">
-            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="content/images/team/tim-m.jpg" alt="Portrait of Tim Mathis">
+            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="/content/images/team/tim-m.jpg" alt="Portrait of Tim Mathis">
             <h5>Tim Mathis</h5>
             <p class="text-muted">Memphis leader</p>
             <ul class="list-inline social-buttons">
@@ -315,7 +315,7 @@
             </ul>
           </div>
           <div class="col-md-6 col-lg-4 text-center px-5 pb-5">
-            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="content/images/team/lawrence-l.jpg" alt="Portrait of Lawrence Lockhart">
+            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="/content/images/team/lawrence-l.jpg" alt="Portrait of Lawrence Lockhart">
             <h5>Lawrence Lockhart</h5>
             <p class="text-muted">Memphis leader</p>
             <ul class="list-inline social-buttons">
@@ -332,7 +332,7 @@
             </ul>
           </div>
           <div class="col-md-6 col-lg-4 text-center px-5 pb-5">
-            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="content/images/team/james-q.jpg" alt="Portrait of James Q. Quick">
+            <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="/content/images/team/james-q.jpg" alt="Portrait of James Q. Quick">
             <h5>James Q. Quick</h5>
             <p class="text-muted">Memphis leader</p>
             <ul class="list-inline social-buttons">
@@ -349,7 +349,7 @@
             </ul>
           </div>
           <div class="col-md-6 col-lg-4 text-center px-5 pb-5">
-              <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="content/images/team/amanda-l.jpg" alt="Portrait of Amanda Lane">
+              <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="/content/images/team/amanda-l.jpg" alt="Portrait of Amanda Lane">
               <h5>Amanda Lane</h5>
               <p class="text-muted">Project Manager</p>
               <ul class="list-inline social-buttons">
@@ -361,7 +361,7 @@
               </ul>
             </div>
             <div class="col-md-6 col-lg-4 text-center px-5 pb-5">
-              <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="content/images/team/ted-p.jpg" alt="Portrait of Ted Patterson">
+              <img class="mx-auto rounded-circle img-fluid mb-3" style="max-width: 60%;" src="/content/images/team/ted-p.jpg" alt="Portrait of Ted Patterson">
               <h5>Ted Patterson</h5>
               <p class="text-muted">General Manager /<br>Lehigh Valley leader</p>
               <ul class="list-inline social-buttons">
@@ -394,7 +394,7 @@
           <p class="py-4">We think that's great and would love to talk with you!</p>
           <div>
             <a class="btn btn-light btn-lg mb-3 mb-md-0 mr-0 mr-md-3 shadow js-scroll-trigger" href="#contact">Connect</a>
-            <a class="btn btn-light btn-lg shadow" href="volunteer.html">Learn more</a>
+            <a class="btn btn-light btn-lg shadow" href="/volunteer">Learn more</a>
           </div>
         </div>
       </div>
@@ -412,26 +412,26 @@
           </div>
         </div>
         <div class="partner-logos">
-          <div class="slide"><img src="content/images/sponsors/base-dark.png" alt="BASE (Birmingham Alabama Software Enthusiasts"></div>
-          <div class="slide"><img src="content/images/sponsors/einsteinbagels-dark.gif" alt="Einstein Bros. Bagels" style="width: 50%;"></div>
-          <div class="slide"><img src="content/images/sponsors/epicenter-dark.png" alt="Epicenter Memphis"></div>
-          <div class="slide"><img src="content/images/sponsors/memtech-dark.gif" alt="Memphis Technology Foundation"></div>
-          <div class="slide"><img src="content/images/sponsors/awaken-dark.gif" alt="Awaken Coffee" style="width: 50%;"></div>
-          <div class="slide"><img src="content/images/sponsors/lehighvalleytech-dark.png" alt="Lehigh Valley Tech" style="width: 50%;"></div>
-          <div class="slide"><img src="content/images/sponsors/codecrew-dark.gif" alt="CodeCrew"></div>
-          <div class="slide"><img src="content/images/sponsors/knoxdevs-dark.gif" alt="KnoxDevs" style="width: 50%;"></div>
-          <div class="slide"><img src="content/images/sponsors/coworkingnight-dark.png" alt="CoWorking Night"></div>
-          <div class="slide"><img src="content/images/sponsors/innovationdepot-dark.png" alt="Innovation Depot"></div>
-          <div class="slide"><img src="content/images/sponsors/themarket-dark.gif" alt="Downtown Allentown Market"></div>
-          <div class="slide"><img src="content/images/sponsors/cals-dark.gif" alt="Central Arkansas Library System"></div>
-          <div class="slide"><img src="content/images/sponsors/universityofmemphis-dark.gif" alt="University of Memphis"></div>
-          <div class="slide"><img src="content/images/sponsors/i85cyber-dark.gif" alt="I85 Cyber Corridor"></div>
-          <div class="slide"><img src="content/images/sponsors/kec-dark.png" alt="Knoxville Entrepreneur Center"></div>
-          <div class="slide"><img src="content/images/sponsors/lbt-dark.png" alt="Learn Build Teach" style="width: 50%;"></div>
-          <div class="slide"><img src="content/images/sponsors/starbucks-dark.gif" alt="Starbucks Coffee" style="width: 50%;"></div>
-          <div class="slide"><img src="content/images/sponsors/theemptycup-dark.png" alt="The Empty Cup"></div>
-          <div class="slide"><img src="content/images/sponsors/mpl-dark.gif" alt="Memphis Public Libraries" style="width: 50%;"></div>
-          <div class="slide"><img src="content/images/sponsors/bor-dark.gif" alt="Birmingham on Rails"></div>
+          <div class="slide"><img src="/content/images/sponsors/base-dark.png" alt="BASE (Birmingham Alabama Software Enthusiasts"></div>
+          <div class="slide"><img src="/content/images/sponsors/einsteinbagels-dark.gif" alt="Einstein Bros. Bagels" style="width: 50%;"></div>
+          <div class="slide"><img src="/content/images/sponsors/epicenter-dark.png" alt="Epicenter Memphis"></div>
+          <div class="slide"><img src="/content/images/sponsors/memtech-dark.gif" alt="Memphis Technology Foundation"></div>
+          <div class="slide"><img src="/content/images/sponsors/awaken-dark.gif" alt="Awaken Coffee" style="width: 50%;"></div>
+          <div class="slide"><img src="/content/images/sponsors/lehighvalleytech-dark.png" alt="Lehigh Valley Tech" style="width: 50%;"></div>
+          <div class="slide"><img src="/content/images/sponsors/codecrew-dark.gif" alt="CodeCrew"></div>
+          <div class="slide"><img src="/content/images/sponsors/knoxdevs-dark.gif" alt="KnoxDevs" style="width: 50%;"></div>
+          <div class="slide"><img src="/content/images/sponsors/coworkingnight-dark.png" alt="CoWorking Night"></div>
+          <div class="slide"><img src="/content/images/sponsors/innovationdepot-dark.png" alt="Innovation Depot"></div>
+          <div class="slide"><img src="/content/images/sponsors/themarket-dark.gif" alt="Downtown Allentown Market"></div>
+          <div class="slide"><img src="/content/images/sponsors/cals-dark.gif" alt="Central Arkansas Library System"></div>
+          <div class="slide"><img src="/content/images/sponsors/universityofmemphis-dark.gif" alt="University of Memphis"></div>
+          <div class="slide"><img src="/content/images/sponsors/i85cyber-dark.gif" alt="I85 Cyber Corridor"></div>
+          <div class="slide"><img src="/content/images/sponsors/kec-dark.png" alt="Knoxville Entrepreneur Center"></div>
+          <div class="slide"><img src="/content/images/sponsors/lbt-dark.png" alt="Learn Build Teach" style="width: 50%;"></div>
+          <div class="slide"><img src="/content/images/sponsors/starbucks-dark.gif" alt="Starbucks Coffee" style="width: 50%;"></div>
+          <div class="slide"><img src="/content/images/sponsors/theemptycup-dark.png" alt="The Empty Cup"></div>
+          <div class="slide"><img src="/content/images/sponsors/mpl-dark.gif" alt="Memphis Public Libraries" style="width: 50%;"></div>
+          <div class="slide"><img src="/content/images/sponsors/bor-dark.gif" alt="Birmingham on Rails"></div>
         </div>
       </div>
     </section>
@@ -442,7 +442,7 @@
         <div class="row d-flex justify-content-center">
           <div class="col-lg-6 text-center">
             <h1 class="text-primary">Our incredible partner</h1>
-            <img src="content/images/sponsors/memtech-dark.gif" alt="Memphis Technology Foundation" class="img-responsive py-5" style="max-width: 70%;">
+            <img src="/content/images/sponsors/memtech-dark.gif" alt="Memphis Technology Foundation" class="img-responsive py-5" style="max-width: 70%;">
             <p class="text-muted">Memphis Technology Foundation is a group of people and 501(c)(3) organization with a diverse interest in technology looking to raise the tech tide in Memphis, TN and beyond.</p>
           </div>
         </div>
@@ -538,8 +538,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.js"></script>
 
     <!-- Custom scripts for this template -->
-    <script src="js/custom.js"></script>
-    <script src="js/partner-slider.js"></script>
+    <script src="/js/custom.js"></script>
+    <script src="/js/partner-slider.js"></script>
 
   </body>
 

--- a/assistance.html
+++ b/assistance.html
@@ -13,17 +13,17 @@
 
 		<meta property="og:title" content="Code Connector">
 		<meta property="og:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta property="og:image" content="content/link_preview.jpg">
+		<meta property="og:image" content="/content/link_preview.jpg">
 		<meta property="og:url" content="https://www.codeconnective.com">
 
 		<meta name="twitter:title" content="Code Connector">
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta name="twitter:image" content="content/link_preview.jpg">
+		<meta name="twitter:image" content="/content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
-		<link rel="shortcut icon" href="content/favicon.ico">
+		<link rel="shortcut icon" href="/content/favicon.ico">
 
     <title>Assistance</title>
 
@@ -35,8 +35,8 @@
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,600,700,900" rel="stylesheet">
 
     <!-- Custom styles -->
-    <link href="css/core.css" rel="stylesheet">
-    <link href="css/secondary.css" rel="stylesheet">
+    <link href="/css/core.css" rel="stylesheet">
+    <link href="/css/secondary.css" rel="stylesheet">
 
   </head>
 
@@ -52,18 +52,18 @@
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
-              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
+              <a class="nav-link" href="/learn" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Memphis</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Birmingham</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Lehigh Valley</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Knoxville</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">North Mississippi</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Memphis</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Birmingham</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Lehigh Valley</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Knoxville</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -73,13 +73,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
+                <a class="dropdown-item" href="/volunteer" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="/sponsor" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="/assistance" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html" data-target="#">About</a>
+              <a class="nav-link" href="/about" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>
@@ -106,7 +106,7 @@
     <header>
       <div class="overlay"></div>
       <video playsinline="playsinline" autoplay="autoplay" muted="muted" loop="loop">
-        <source src="content/videos/workshop2.mp4" type="video/mp4">
+        <source src="/content/videos/workshop2.mp4" type="video/mp4">
       </video>
       <div class="container h-100">
         <div class="d-flex h-100 text-center align-items-center">
@@ -320,7 +320,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.4.1/jquery.easing.min.js" integrity="sha256-H3cjtrm/ztDeuhCN9I4yh4iN2Ybx/y1RM7rMmAesA0k=" crossorigin="anonymous"></script>
     
     <!-- Custom scripts for this template -->
-    <script src="js/custom.js"></script>
+    <script src="/js/custom.js"></script>
 
   </body>
 

--- a/index.html
+++ b/index.html
@@ -13,17 +13,17 @@
 
 		<meta property="og:title" content="Code Connector">
 		<meta property="og:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta property="og:image" content="content/link_preview.jpg">
+		<meta property="og:image" content="/content/link_preview.jpg">
 		<meta property="og:url" content="https://www.codeconnective.com">
 
 		<meta name="twitter:title" content="Code Connector">
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta name="twitter:image" content="content/link_preview.jpg">
+		<meta name="twitter:image" content="/content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
-		<link rel="shortcut icon" href="content/favicon.ico">
+		<link rel="shortcut icon" href="/content/favicon.ico">
 
     <title>Code Connector</title>
 
@@ -35,8 +35,8 @@
     <link href="https://fonts.googleapis.com/css?family=Raleway:900" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600,900&display=swap" rel="stylesheet">
     <!-- Custom styles -->
-    <link href="css/core.css" rel="stylesheet">
-    <link href="css/primary.css" rel="stylesheet">
+    <link href="/css/core.css" rel="stylesheet">
+    <link href="/css/primary.css" rel="stylesheet">
 
   </head>
 
@@ -52,18 +52,18 @@
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
-              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
+              <a class="nav-link" href="/learn" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Memphis</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Birmingham</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Lehigh Valley</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Knoxville</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">North Mississippi</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Memphis</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Birmingham</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Lehigh Valley</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Knoxville</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -73,13 +73,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
+                <a class="dropdown-item" href="/volunteer" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="/sponsor" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="/assistance" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html" data-target="#">About</a>
+              <a class="nav-link" href="/about" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>
@@ -106,7 +106,7 @@
     <header>
       <div class="overlay"></div>
       <video playsinline="playsinline" autoplay="autoplay" muted="muted" loop="loop">
-        <source src="content/videos/workshop1.mp4" type="video/mp4">
+        <source src="/content/videos/workshop1.mp4" type="video/mp4">
       </video>
       <div class="container h-100">
         <div class="d-flex h-100 align-items-center">
@@ -157,7 +157,7 @@
                 <p class="text-muted mt-4">We've built and are continuing to build a network of local and regional mentors that are excited to help you along the way.</p>                
               </div>
               <div class="card-footer p-4">
-                <a class="btn btn-primary" href="assistance.html">Receive</a> 
+                <a class="btn btn-primary" href="/assistance">Receive</a> 
               </div>
             </div>
           </div>
@@ -172,7 +172,7 @@
                 <p class="text-muted mt-4">Videos, bootcamps, recruiting agencies, college degree programs... there are so many options! We want you to get what you need and at a price you can afford.</p>                
               </div>
               <div class="card-footer p-4">
-                <a class="btn btn-primary" href="learn.html">Start</a>   
+                <a class="btn btn-primary" href="/learn">Start</a>   
               </div>
             </div>
           </div>
@@ -225,12 +225,12 @@
             <p class="text-muted">Having to learn something new on top of full-time work or taking care of kids is tough. With this in mind, we keep things easy to understand and at an undemanding pace.</p>
           </div>
           <div class="col-md-6 order-1 order-md-2">
-            <img src="content/images/meetups/color/5by7/14.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendee examining laptop with mentor">
+            <img src="/content/images/meetups/color/5by7/14.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendee examining laptop with mentor">
           </div>
         </div>
         <div class="row py-5 d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/20a.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees having a good time at two tables">
+            <img src="/content/images/meetups/color/5by7/20a.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees having a good time at two tables">
           </div>
           <div class="col-md-4 ml-md-4 text-center text-md-left">
             <h1 class="text-primary">Improved</h1>
@@ -245,12 +245,12 @@
             <p class="text-muted">Our goal is that attendees always leave being more prepared for their course work, next task, or job interview.</p>
           </div>
           <div class="col-md-6 order-1 order-md-2">
-            <img src="content/images/meetups/color/5by7/8.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees standing for group photo">
+            <img src="/content/images/meetups/color/5by7/8.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees standing for group photo">
           </div>
         </div>
         <div class="row py-5 d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/12.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees working on code and observing others at work">
+            <img src="/content/images/meetups/color/5by7/12.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees working on code and observing others at work">
           </div>
           <div class="col-md-4 ml-md-4 text-center text-md-left">
             <h1 class="text-primary">Affordable</h1>
@@ -283,7 +283,7 @@
             <div class="card-footer border-top">
               <div class="row d-flex align-items-center">
                 <div class="col-2 mr-3">
-                  <img class="img-responsive border mr-3" src="content/images/testimonials/1.png" alt="Portrait of Demetria Farewell" style="width: 50px; border-radius: 5rem;">
+                  <img class="img-responsive border mr-3" src="/content/images/testimonials/1.png" alt="Portrait of Demetria Farewell" style="width: 50px; border-radius: 5rem;">
                 </div>
                 <div class="col">
                   <p class="mb-0">Demetria Farewell</p>
@@ -305,7 +305,7 @@
             <div class="card-footer border-top">
               <div class="row d-flex align-items-center">
                 <div class="col-2 mr-3">
-                  <img class="img-responsive border mr-3" src="content/images/testimonials/2.png" alt="Portrait of David Nguyễn" style="width: 50px; border-radius: 5rem;">
+                  <img class="img-responsive border mr-3" src="/content/images/testimonials/2.png" alt="Portrait of David Nguyễn" style="width: 50px; border-radius: 5rem;">
                 </div>
                 <div class="col">
                   <p class="mb-0">David Nguyen</p>
@@ -328,7 +328,7 @@
             <div class="card-footer border-top">
               <div class="row d-flex align-items-center">
                 <div class="col-2 mr-3">
-                  <img class="img-responsive border mr-3" src="content/images/testimonials/3.png" alt="Portrait of Jordan Parker" style="width: 50px; border-radius: 5rem;">
+                  <img class="img-responsive border mr-3" src="/content/images/testimonials/3.png" alt="Portrait of Jordan Parker" style="width: 50px; border-radius: 5rem;">
                 </div>
                 <div class="col">
                   <p class="mb-0">Jordan Parker</p>
@@ -352,7 +352,7 @@
             <div class="card-footer border-top">
               <div class="row d-flex align-items-center">
                 <div class="col-2 mr-3">
-                  <img class="img-responsive border mr-3" src="content/images/testimonials/4.jpg" alt="Portrait of Walker Laury" style="width: 50px; border-radius: 5rem;">
+                  <img class="img-responsive border mr-3" src="/content/images/testimonials/4.jpg" alt="Portrait of Walker Laury" style="width: 50px; border-radius: 5rem;">
                 </div>
                 <div class="col">
                   <p class="mb-0">Walker Laury</p>
@@ -374,7 +374,7 @@
             <div class="card-footer border-top">
               <div class="row d-flex align-items-center">
                 <div class="col-2 mr-3">
-                  <img class="img-responsive border mr-3" src="content/images/testimonials/5.png" alt="Portrait of Autumn Ragland" style="width: 50px; border-radius: 5rem;">
+                  <img class="img-responsive border mr-3" src="/content/images/testimonials/5.png" alt="Portrait of Autumn Ragland" style="width: 50px; border-radius: 5rem;">
                 </div>
                 <div class="col">
                   <p class="mb-0">Autumn Ragland</p>
@@ -397,7 +397,7 @@
             <div class="card-footer border-top">
               <div class="row d-flex align-items-center">
                 <div class="col-2 mr-3">
-                  <img class="img-responsive border mr-3" src="content/images/testimonials/6.jpg" alt="Portrait of George Spake" style="width: 50px; border-radius: 5rem;">
+                  <img class="img-responsive border mr-3" src="/content/images/testimonials/6.jpg" alt="Portrait of George Spake" style="width: 50px; border-radius: 5rem;">
                 </div>
                 <div class="col">
                   <p class="mb-0">George Spake</p>
@@ -419,7 +419,7 @@
             <div class="card-footer border-top">
               <div class="row d-flex align-items-center">
                 <div class="col-2 mr-3">
-                  <img class="img-responsive border mr-3" src="content/images/testimonials/7.jpg" alt="Portrait of Brandon Herlong" style="width: 50px; border-radius: 5rem;">
+                  <img class="img-responsive border mr-3" src="/content/images/testimonials/7.jpg" alt="Portrait of Brandon Herlong" style="width: 50px; border-radius: 5rem;">
                 </div>
                 <div class="col">
                   <p class="mb-0">Brandon Herlong</p>
@@ -441,7 +441,7 @@
             <div class="card-footer border-top">
               <div class="row d-flex align-items-center">
                 <div class="col-2 mr-3">
-                  <img class="img-responsive border mr-3" src="content/images/testimonials/8.jpg" alt="Portrait of Alan Carpenter" style="width: 50px; border-radius: 5rem;">
+                  <img class="img-responsive border mr-3" src="/content/images/testimonials/8.jpg" alt="Portrait of Alan Carpenter" style="width: 50px; border-radius: 5rem;">
                 </div>
                 <div class="col">
                   <p class="mb-0">Alan Carpenter</p>
@@ -577,14 +577,14 @@
           </div>
         </div>
           <ol class="carousel-indicators">
-            <li data-target="#carouselExampleIndicators" data-slide-to="0" class="active"><img class="img-responsive w-100 shadow" src="content/images/testimonials/1.png" alt="Portrait of Demetria Farewell"></li>
-            <li data-target="#carouselExampleIndicators" data-slide-to="1"><img class="img-responsive w-100" src="content/images/testimonials/2.png" alt="Portrait of David Nguyễn"></li>
-            <li data-target="#carouselExampleIndicators" data-slide-to="2"><img class="img-responsive w-100" src="content/images/testimonials/3.png" alt="Portrait of Jordan Parker"></li>
-            <li data-target="#carouselExampleIndicators" data-slide-to="3"><img class="img-responsive w-100" src="content/images/testimonials/4.jpg" alt="Portrait of Walker Laury"></li>
-            <li data-target="#carouselExampleIndicators" data-slide-to="4"><img class="img-responsive w-100" src="content/images/testimonials/5.png" alt="Portrait of Autumn Ragland"></li>
-            <li data-target="#carouselExampleIndicators" data-slide-to="5"><img class="img-responsive w-100" src="content/images/testimonials/6.jpg" alt="Portrait of George Spake"></li>
-            <li data-target="#carouselExampleIndicators" data-slide-to="6"><img class="img-responsive w-100" src="content/images/testimonials/7.jpg" alt="Portrait of Brandon Herlong"></li>
-            <li data-target="#carouselExampleIndicators" data-slide-to="7"><img class="img-responsive w-100" src="content/images/testimonials/8.jpg" alt="Portrait of Alan Carpenter"></li>
+            <li data-target="#carouselExampleIndicators" data-slide-to="0" class="active"><img class="img-responsive w-100 shadow" src="/content/images/testimonials/1.png" alt="Portrait of Demetria Farewell"></li>
+            <li data-target="#carouselExampleIndicators" data-slide-to="1"><img class="img-responsive w-100" src="/content/images/testimonials/2.png" alt="Portrait of David Nguyễn"></li>
+            <li data-target="#carouselExampleIndicators" data-slide-to="2"><img class="img-responsive w-100" src="/content/images/testimonials/3.png" alt="Portrait of Jordan Parker"></li>
+            <li data-target="#carouselExampleIndicators" data-slide-to="3"><img class="img-responsive w-100" src="/content/images/testimonials/4.jpg" alt="Portrait of Walker Laury"></li>
+            <li data-target="#carouselExampleIndicators" data-slide-to="4"><img class="img-responsive w-100" src="/content/images/testimonials/5.png" alt="Portrait of Autumn Ragland"></li>
+            <li data-target="#carouselExampleIndicators" data-slide-to="5"><img class="img-responsive w-100" src="/content/images/testimonials/6.jpg" alt="Portrait of George Spake"></li>
+            <li data-target="#carouselExampleIndicators" data-slide-to="6"><img class="img-responsive w-100" src="/content/images/testimonials/7.jpg" alt="Portrait of Brandon Herlong"></li>
+            <li data-target="#carouselExampleIndicators" data-slide-to="7"><img class="img-responsive w-100" src="/content/images/testimonials/8.jpg" alt="Portrait of Alan Carpenter"></li>
           </ol>
       </div>
     </section>
@@ -598,33 +598,33 @@
           </div>
         </div>
         <div class="partner-logos py-5">
-          <div class="slide"><img src="content/images/sponsors/base-light.png" alt="BASE (Birmingham Alabama Software Enthusiasts"></div>
-          <div class="slide"><img src="content/images/sponsors/einsteinbagels-light.gif" alt="Einstein Bros. Bagels" style="width: 50%;"></div>
-          <div class="slide"><img src="content/images/sponsors/epicenter-light.png" alt="Epicenter Memphis"></div>
-          <div class="slide"><img src="content/images/sponsors/memtech-light.gif" alt="Memphis Technology Foundation"></div>
-          <div class="slide"><img src="content/images/sponsors/awaken-light.gif" alt="Awaken Coffee" style="width: 50%;"></div>
-          <div class="slide"><img src="content/images/sponsors/lehighvalleytech-light.png" alt="Lehigh Valley Tech" style="width: 50%;"></div>
-          <div class="slide"><img src="content/images/sponsors/codecrew-light.gif" alt="CodeCrew"></div>
-          <div class="slide"><img src="content/images/sponsors/knoxdevs-light.gif" alt="KnoxDevs" style="width: 50%;"></div>
-          <div class="slide"><img src="content/images/sponsors/coworkingnight-light.png" alt="CoWorking Night"></div>
-          <div class="slide"><img src="content/images/sponsors/innovationdepot-light.png" alt="Innovation Depot"></div>
-          <div class="slide"><img src="content/images/sponsors/themarket-light.gif" alt="Downtown Allentown Market"></div>
-          <div class="slide"><img src="content/images/sponsors/cals-light.gif" alt="Central Arkansas Library System"></div>
-          <div class="slide"><img src="content/images/sponsors/universityofmemphis-light.gif" alt="University of Memphis"></div>
-          <div class="slide"><img src="content/images/sponsors/i85cyber-light.gif" alt="I85 Cyber Corridor"></div>
-          <div class="slide"><img src="content/images/sponsors/kec-light.png" alt="Knoxville Entrepreneur Center"></div>
-          <div class="slide"><img src="content/images/sponsors/lbt-light.png" alt="Learn Build Teach" style="width: 50%;"></div>
-          <div class="slide"><img src="content/images/sponsors/starbucks-light.gif" alt="Starbucks Coffee" style="width: 50%;"></div>
-          <div class="slide"><img src="content/images/sponsors/theemptycup-light.png" alt="The Empty Cup"></div>
-          <div class="slide"><img src="content/images/sponsors/mpl-light.gif" alt="Memphis Public Libraries" style="width: 50%;"></div>
-          <div class="slide"><img src="content/images/sponsors/bor-light.gif" alt="Birmingham on Rails"></div>
+          <div class="slide"><img src="/content/images/sponsors/base-light.png" alt="BASE (Birmingham Alabama Software Enthusiasts"></div>
+          <div class="slide"><img src="/content/images/sponsors/einsteinbagels-light.gif" alt="Einstein Bros. Bagels" style="width: 50%;"></div>
+          <div class="slide"><img src="/content/images/sponsors/epicenter-light.png" alt="Epicenter Memphis"></div>
+          <div class="slide"><img src="/content/images/sponsors/memtech-light.gif" alt="Memphis Technology Foundation"></div>
+          <div class="slide"><img src="/content/images/sponsors/awaken-light.gif" alt="Awaken Coffee" style="width: 50%;"></div>
+          <div class="slide"><img src="/content/images/sponsors/lehighvalleytech-light.png" alt="Lehigh Valley Tech" style="width: 50%;"></div>
+          <div class="slide"><img src="/content/images/sponsors/codecrew-light.gif" alt="CodeCrew"></div>
+          <div class="slide"><img src="/content/images/sponsors/knoxdevs-light.gif" alt="KnoxDevs" style="width: 50%;"></div>
+          <div class="slide"><img src="/content/images/sponsors/coworkingnight-light.png" alt="CoWorking Night"></div>
+          <div class="slide"><img src="/content/images/sponsors/innovationdepot-light.png" alt="Innovation Depot"></div>
+          <div class="slide"><img src="/content/images/sponsors/themarket-light.gif" alt="Downtown Allentown Market"></div>
+          <div class="slide"><img src="/content/images/sponsors/cals-light.gif" alt="Central Arkansas Library System"></div>
+          <div class="slide"><img src="/content/images/sponsors/universityofmemphis-light.gif" alt="University of Memphis"></div>
+          <div class="slide"><img src="/content/images/sponsors/i85cyber-light.gif" alt="I85 Cyber Corridor"></div>
+          <div class="slide"><img src="/content/images/sponsors/kec-light.png" alt="Knoxville Entrepreneur Center"></div>
+          <div class="slide"><img src="/content/images/sponsors/lbt-light.png" alt="Learn Build Teach" style="width: 50%;"></div>
+          <div class="slide"><img src="/content/images/sponsors/starbucks-light.gif" alt="Starbucks Coffee" style="width: 50%;"></div>
+          <div class="slide"><img src="/content/images/sponsors/theemptycup-light.png" alt="The Empty Cup"></div>
+          <div class="slide"><img src="/content/images/sponsors/mpl-light.gif" alt="Memphis Public Libraries" style="width: 50%;"></div>
+          <div class="slide"><img src="/content/images/sponsors/bor-light.gif" alt="Birmingham on Rails"></div>
         </div>
         <div class="row pt-5 d-flex justify-content-center">
           <div class="col-lg-6 text-center text-light">
             <p>We're especially thankful to be supported by the awesome folks at <a href="https://memphistechnology.org/" target="_blank" class="text-white">Memphis Technology Foundation</a>.</p>
             <a href="about.html#partner" class="btn btn-light shadow mt-3">Learn more</a>
             <!--
-            <a class="btn btn-light shadow mt-3 text-wrap" href="about.html">Learn about our partnership</a>
+            <a class="btn btn-light shadow mt-3 text-wrap" href="/about">Learn about our partnership</a>
             -->
           </div>
         </div>
@@ -706,7 +706,7 @@
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
 
     <!-- Typed JavaScript -->
-    <script src="js/typed.js"></script>
+    <script src="/js/typed.js"></script>
     <script>
       var typed = new Typed("#typed", {
         strings: ['a lonely', 'a frustrating', 'an expensive', 'an aimless', 'an exhausting', 'a difficult'],
@@ -724,8 +724,8 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/slick-carousel/1.6.0/slick.js"></script>
 
     <!-- Custom scripts for this template -->
-    <script src="js/custom.js"></script>
-    <script src="js/partner-slider.js"></script>
+    <script src="/js/custom.js"></script>
+    <script src="/js/partner-slider.js"></script>
 
   </body>
 

--- a/knoxville.html
+++ b/knoxville.html
@@ -13,17 +13,17 @@
 
 		<meta property="og:title" content="Code Connector">
 		<meta property="og:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta property="og:image" content="content/link_preview.jpg">
+		<meta property="og:image" content="/content/link_preview.jpg">
 		<meta property="og:url" content="https://www.codeconnective.com">
 
 		<meta name="twitter:title" content="Code Connector">
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta name="twitter:image" content="content/link_preview.jpg">
+		<meta name="twitter:image" content="/content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
-		<link rel="shortcut icon" href="content/favicon.ico">
+		<link rel="shortcut icon" href="/content/favicon.ico">
 
     <title>Knoxville</title>
 
@@ -36,8 +36,8 @@
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,600,700,900" rel="stylesheet">
 
     <!-- Custom styles -->
-    <link href="css/core.css" rel="stylesheet">
-    <link href="css/secondary.css" rel="stylesheet">
+    <link href="/css/core.css" rel="stylesheet">
+    <link href="/css/secondary.css" rel="stylesheet">
 
   </head>
 
@@ -52,18 +52,18 @@
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
-              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
+              <a class="nav-link" href="/learn" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
+                <a class="dropdown-item" href="/memphis" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="/birmingham" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="/knoxville" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="/montgomery" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="/northmississippi" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -73,13 +73,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
+                <a class="dropdown-item" href="/volunteer" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="/sponsor" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="/assistance" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html" data-target="#">About</a>
+              <a class="nav-link" href="/about" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>
@@ -106,7 +106,7 @@
     <header>
       <div class="overlay"></div>
       <video playsinline="playsinline" autoplay="autoplay" muted="muted" loop="loop">
-        <source src="content/videos/talk2.mp4" type="video/mp4">
+        <source src="/content/videos/talk2.mp4" type="video/mp4">
       </video>
       <div class="container h-100">
         <div class="d-flex h-100 text-center align-items-center">
@@ -125,7 +125,7 @@
           <div class="col-md-12 col-lg-6 pb-4 mb-md-0">
             <div class="card shadow">
               <div class="card-body">
-                <img src="content/images/flyers/CodeTogether-Knoxville.jpg" class="img-fluid rounded mb-3" alt="Code Together Knoxville flyer">
+                <img src="/content/images/flyers/CodeTogether-Knoxville.jpg" class="img-fluid rounded mb-3" alt="Code Together Knoxville flyer">
                 <div class="row d-flex justify-content-center">
                   <div class="col-md-4">
                       <a class="btn btn-primary btn-block mb-3 mb-md-0" href="https://www.facebook.com/events/285612179020637/" target="_blank">Facebook</a>
@@ -181,7 +181,7 @@
         </div>
         <div class="row d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/3.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees posing for group photo (includes bunny ears)">
+            <img src="/content/images/meetups/color/5by7/3.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees posing for group photo (includes bunny ears)">
           </div>
           <div class="col-md-4 ml-lg-4 text-center text-md-left">
             <p class="text-muted">These gatherings aren't classes, so there won't be a teacher, but it is your opportunity to talk with other beginners, mentors, and leaders in your local community. You'll get help jumpstarting the learning process or tackling that programming lesson / personal project you've been working on.</p>
@@ -232,7 +232,7 @@
         </div>
         <div class="row py-5 d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/6.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Two pairs of attendees conversing over code at table">
+            <img src="/content/images/meetups/color/5by7/6.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Two pairs of attendees conversing over code at table">
           </div>
           <div class="col-md-4 ml-md-4 text-center text-md-left">
             <h1 class="text-primary">Rewarding</h1>
@@ -247,12 +247,12 @@
             <p class="text-muted">Having to learn something new on top of full-time work or taking care of kids is tough. With this in mind, we keep things easy to understand and at an undemanding pace.</p>
           </div>
           <div class="col-md-6 order-1 order-md-2">
-            <img src="content/images/meetups/color/5by7/14.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendee examining laptop with mentor">
+            <img src="/content/images/meetups/color/5by7/14.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendee examining laptop with mentor">
           </div>
         </div>
         <div class="row py-5 d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/1.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees having group discussion">
+            <img src="/content/images/meetups/color/5by7/1.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees having group discussion">
           </div>
           <div class="col-md-4 ml-md-4 text-center text-md-left">
             <h1 class="text-primary">Affordable</h1>
@@ -376,7 +376,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.4.1/jquery.easing.min.js" integrity="sha256-H3cjtrm/ztDeuhCN9I4yh4iN2Ybx/y1RM7rMmAesA0k=" crossorigin="anonymous"></script>
     
     <!-- Custom scripts for this template -->
-    <script src="js/custom.js"></script>
+    <script src="/js/custom.js"></script>
 
   </body>
 

--- a/learn.html
+++ b/learn.html
@@ -13,17 +13,17 @@
 
 		<meta property="og:title" content="Code Connector">
 		<meta property="og:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta property="og:image" content="content/link_preview.jpg">
+		<meta property="og:image" content="/content/link_preview.jpg">
 		<meta property="og:url" content="https://www.codeconnective.com">
 
 		<meta name="twitter:title" content="Code Connector">
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta name="twitter:image" content="content/link_preview.jpg">
+		<meta name="twitter:image" content="/content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
-		<link rel="shortcut icon" href="content/favicon.ico">
+		<link rel="shortcut icon" href="/content/favicon.ico">
 
     <title>Learn</title>
 
@@ -36,8 +36,8 @@
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,600,700,900" rel="stylesheet">
 
     <!-- Custom styles -->
-    <link href="css/core.css" rel="stylesheet">
-    <link href="css/secondary.css" rel="stylesheet">
+    <link href="/css/core.css" rel="stylesheet">
+    <link href="/css/secondary.css" rel="stylesheet">
 
   </head>
 
@@ -52,18 +52,18 @@
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
-              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
+              <a class="nav-link" href="/learn" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Memphis</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Birmingham</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Lehigh Valley</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Knoxville</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">North Mississippi</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Memphis</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Birmingham</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Lehigh Valley</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Knoxville</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -73,13 +73,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
+                <a class="dropdown-item" href="/volunteer" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="/sponsor" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="/assistance" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html" data-target="#">About</a>
+              <a class="nav-link" href="/about" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>
@@ -106,7 +106,7 @@
     <header>
       <div class="overlay"></div>
       <video playsinline="playsinline" autoplay="autoplay" muted="muted" loop="loop">
-        <source src="content/videos/talk2.mp4" type="video/mp4">
+        <source src="/content/videos/talk2.mp4" type="video/mp4">
       </video>
       <div class="container h-100">
         <div class="d-flex h-100 text-center align-items-center">
@@ -173,12 +173,12 @@
             <p>Thanks to Slack, no matter the device or system, help is always one click and message away.</p>
           </div>
           <div class="col-md-6 order-1 order-md-2">
-            <img src="content/images/slack/5by7/1.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees having group discussion">
+            <img src="/content/images/slack/5by7/1.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees having group discussion">
           </div>
         </div>
         <div class="row py-5 d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/people/3.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Three attendees seated at a couch check out what the middle attendee is doing on her laptop">
+            <img src="/content/images/people/3.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Three attendees seated at a couch check out what the middle attendee is doing on her laptop">
           </div>
           <div class="col-md-4 ml-md-4 text-center text-md-left text-light">
             <h1>Open</h1>
@@ -193,7 +193,7 @@
             <p>The overall mission of this platform is to set up a cooperative place that pushes people to succeed. From study buddies to job lead motivation, help is on its way!</p>
           </div>
           <div class="col-md-6 order-1 order-md-2">
-            <img src="content/images/people/2.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Top down view of attendee coding on her laptop">
+            <img src="/content/images/people/2.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Top down view of attendee coding on her laptop">
           </div>
         </div>
         <div class="row text-center justify-content-center my-md-5 my-2 pt-md-5">
@@ -214,7 +214,7 @@
         </div>
         <div class="row py-5 d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/8.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees standing for group photo">
+            <img src="/content/images/meetups/color/5by7/8.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees standing for group photo">
           </div>
           <div class="col-md-4 ml-lg-4 text-center text-md-left">
             <p class="text-muted">These gatherings aren't class, so there won't be a teacher, but it is your opportunity to talk with other people and get help jumpstarting your learning process or with a programming lesson / personal project you've been working on.</p>
@@ -335,7 +335,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.4.1/jquery.easing.min.js" integrity="sha256-H3cjtrm/ztDeuhCN9I4yh4iN2Ybx/y1RM7rMmAesA0k=" crossorigin="anonymous"></script>
     
     <!-- Custom scripts for this template -->
-    <script src="js/custom.js"></script>
+    <script src="/js/custom.js"></script>
 
   </body>
 

--- a/memphis.html
+++ b/memphis.html
@@ -13,17 +13,17 @@
 
 		<meta property="og:title" content="Code Connector">
 		<meta property="og:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta property="og:image" content="content/link_preview.jpg">
+		<meta property="og:image" content="/content/link_preview.jpg">
 		<meta property="og:url" content="https://www.codeconnective.com">
 
 		<meta name="twitter:title" content="Code Connector">
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta name="twitter:image" content="content/link_preview.jpg">
+		<meta name="twitter:image" content="/content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
-		<link rel="shortcut icon" href="content/favicon.ico">
+		<link rel="shortcut icon" href="/content/favicon.ico">
 
     <title>Memphis</title>
 
@@ -36,8 +36,8 @@
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,600,700,900" rel="stylesheet">
 
     <!-- Custom styles -->
-    <link href="css/core.css" rel="stylesheet">
-    <link href="css/secondary.css" rel="stylesheet">
+    <link href="/css/core.css" rel="stylesheet">
+    <link href="/css/secondary.css" rel="stylesheet">
 
   </head>
 
@@ -52,18 +52,18 @@
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
-              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
+              <a class="nav-link" href="/learn" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
+                <a class="dropdown-item" href="/memphis" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="/birmingham" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="/knoxville" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="/montgomery" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="/northmississippi" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -73,13 +73,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
+                <a class="dropdown-item" href="/volunteer" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="/sponsor" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="/assistance" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html" data-target="#">About</a>
+              <a class="nav-link" href="/about" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>
@@ -106,7 +106,7 @@
     <header>
       <div class="overlay"></div>
       <video playsinline="playsinline" autoplay="autoplay" muted="muted" loop="loop">
-        <source src="content/videos/talk2.mp4" type="video/mp4">
+        <source src="/content/videos/talk2.mp4" type="video/mp4">
       </video>
       <div class="container h-100">
         <div class="d-flex h-100 text-center align-items-center">
@@ -125,7 +125,7 @@
             <div class="col-md-12 col-lg-6 pb-4 mb-md-0">
               <div class="card shadow">
                 <div class="card-body">
-                  <img src="content/images/flyers/CodeCoop-Memphis.jpg" class="img-fluid rounded mb-3" alt="Code Co-op Memphis flyer">
+                  <img src="/content/images/flyers/CodeCoop-Memphis.jpg" class="img-fluid rounded mb-3" alt="Code Co-op Memphis flyer">
                   <div class="row">
                     <div class="col-md-4">
                         <a class="btn btn-primary btn-block mb-3 mb-md-0" href="https://www.facebook.com/events/504740363381972/" target="_blank">Facebook</a>
@@ -163,7 +163,7 @@
           <div class="col-md-12 col-lg-6 pb-4 mb-md-0">
             <div class="card shadow">
               <div class="card-body">
-                <img src="content/images/flyers/CodeTogether-Memphis.jpg" class="img-fluid rounded mb-3" alt="Code Together Memphis flyer">
+                <img src="/content/images/flyers/CodeTogether-Memphis.jpg" class="img-fluid rounded mb-3" alt="Code Together Memphis flyer">
                 <div class="row">
                   <div class="col-md-4">
                       <a class="btn btn-primary btn-block mb-3 mb-md-0" href="https://www.facebook.com/events/298247124067287/" target="_blank">Facebook</a>
@@ -219,7 +219,7 @@
         </div>
         <div class="row d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/14.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendee examining laptop with mentor">
+            <img src="/content/images/meetups/color/5by7/14.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendee examining laptop with mentor">
           </div>
           <div class="col-md-4 ml-lg-4 text-center text-md-left">
             <p class="text-muted">These get together aren't always classes, so there may not be a teacher, but no matter the setup this will be your opportunity to talk with other beginners, mentors, and leaders in your local community. You'll get help jumpstarting the learning process or tackling that tech lesson / personal project you've been working on.</p>
@@ -270,7 +270,7 @@
         </div>
         <div class="row py-5 d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/6.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Two pairs of attendees conversing over code at table">
+            <img src="/content/images/meetups/color/5by7/6.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Two pairs of attendees conversing over code at table">
           </div>
           <div class="col-md-4 ml-md-4 text-center text-md-left">
             <h1 class="text-primary">Rewarding</h1>
@@ -285,12 +285,12 @@
             <p class="text-muted">Having to learn something new on top of full-time work or taking care of kids is tough. With this in mind, we keep things easy to understand and at an undemanding pace.</p>
           </div>
           <div class="col-md-6 order-1 order-md-2">
-            <img src="content/images/meetups/color/5by7/14.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendee examining laptop with mentor">
+            <img src="/content/images/meetups/color/5by7/14.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendee examining laptop with mentor">
           </div>
         </div>
         <div class="row py-5 d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/1.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees having group discussion">
+            <img src="/content/images/meetups/color/5by7/1.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees having group discussion">
           </div>
           <div class="col-md-4 ml-md-4 text-center text-md-left">
             <h1 class="text-primary">Affordable</h1>
@@ -414,7 +414,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.4.1/jquery.easing.min.js" integrity="sha256-H3cjtrm/ztDeuhCN9I4yh4iN2Ybx/y1RM7rMmAesA0k=" crossorigin="anonymous"></script>
     
     <!-- Custom scripts for this template -->
-    <script src="js/custom.js"></script>
+    <script src="/js/custom.js"></script>
 
   </body>
 

--- a/montgomery.html
+++ b/montgomery.html
@@ -13,17 +13,17 @@
 
 		<meta property="og:title" content="Code Connector">
 		<meta property="og:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta property="og:image" content="content/link_preview.jpg">
+		<meta property="og:image" content="/content/link_preview.jpg">
 		<meta property="og:url" content="https://www.codeconnective.com">
 
 		<meta name="twitter:title" content="Code Connector">
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta name="twitter:image" content="content/link_preview.jpg">
+		<meta name="twitter:image" content="/content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
-		<link rel="shortcut icon" href="content/favicon.ico">
+		<link rel="shortcut icon" href="/content/favicon.ico">
 
     <title>Montgomery</title>
 
@@ -36,8 +36,8 @@
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,600,700,900" rel="stylesheet">
 
     <!-- Custom styles -->
-    <link href="css/core.css" rel="stylesheet">
-    <link href="css/secondary.css" rel="stylesheet">
+    <link href="/css/core.css" rel="stylesheet">
+    <link href="/css/secondary.css" rel="stylesheet">
 
   </head>
 
@@ -52,18 +52,18 @@
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
-              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
+              <a class="nav-link" href="/learn" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
+                <a class="dropdown-item" href="/memphis" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="/birmingham" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="/knoxville" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="/montgomery" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="/northmississippi" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -73,13 +73,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
+                <a class="dropdown-item" href="/volunteer" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="/sponsor" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="/assistance" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html" data-target="#">About</a>
+              <a class="nav-link" href="/about" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>
@@ -106,7 +106,7 @@
     <header>
       <div class="overlay"></div>
       <video playsinline="playsinline" autoplay="autoplay" muted="muted" loop="loop">
-        <source src="content/videos/talk2.mp4" type="video/mp4">
+        <source src="/content/videos/talk2.mp4" type="video/mp4">
       </video>
       <div class="container h-100">
         <div class="d-flex h-100 text-center align-items-center">
@@ -125,7 +125,7 @@
           <div class="col-md-12 col-lg-6 pb-4 mb-md-0">
             <div class="card shadow">
               <div class="card-body">
-                <img src="content/images/flyers/CodeTogether-Montgomery.jpg" class="img-fluid rounded mb-3" alt="Code Together Montgomery flyer">
+                <img src="/content/images/flyers/CodeTogether-Montgomery.jpg" class="img-fluid rounded mb-3" alt="Code Together Montgomery flyer">
                 <div class="row d-flex justify-content-center align-items-center">
                   <div class="col-md-4">
                       <a class="btn btn-primary btn-block mb-3 mb-md-0" href="https://www.facebook.com/events/838603339804457/" target="_blank">Facebook</a>
@@ -158,7 +158,7 @@
         </div>
         <div class="row d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/2.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees watching presentation (out of frame)">
+            <img src="/content/images/meetups/color/5by7/2.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees watching presentation (out of frame)">
           </div>
           <div class="col-md-4 ml-lg-4 text-center text-md-left">
             <p class="text-muted">These gatherings aren't classes, so there won't be a teacher, but it is your opportunity to talk with other beginners, mentors, and leaders in your local community. You'll get help jumpstarting the learning process or tackling that programming lesson / personal project you've been working on.</p>
@@ -209,7 +209,7 @@
         </div>
         <div class="row py-5 d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/6.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Two pairs of attendees conversing over code at table">
+            <img src="/content/images/meetups/color/5by7/6.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Two pairs of attendees conversing over code at table">
           </div>
           <div class="col-md-4 ml-md-4 text-center text-md-left">
             <h1 class="text-primary">Rewarding</h1>
@@ -224,12 +224,12 @@
             <p class="text-muted">Having to learn something new on top of full-time work or taking care of kids is tough. With this in mind, we keep things easy to understand and at an undemanding pace.</p>
           </div>
           <div class="col-md-6 order-1 order-md-2">
-            <img src="content/images/meetups/color/5by7/14.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendee examining laptop with mentor">
+            <img src="/content/images/meetups/color/5by7/14.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendee examining laptop with mentor">
           </div>
         </div>
         <div class="row py-5 d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/1.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees having group discussion">
+            <img src="/content/images/meetups/color/5by7/1.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees having group discussion">
           </div>
           <div class="col-md-4 ml-md-4 text-center text-md-left">
             <h1 class="text-primary">Affordable</h1>
@@ -353,7 +353,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.4.1/jquery.easing.min.js" integrity="sha256-H3cjtrm/ztDeuhCN9I4yh4iN2Ybx/y1RM7rMmAesA0k=" crossorigin="anonymous"></script>
     
     <!-- Custom scripts for this template -->
-    <script src="js/custom.js"></script>
+    <script src="/js/custom.js"></script>
 
   </body>
 

--- a/northmississippi.html
+++ b/northmississippi.html
@@ -13,17 +13,17 @@
 
 		<meta property="og:title" content="Code Connector">
 		<meta property="og:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta property="og:image" content="content/link_preview.jpg">
+		<meta property="og:image" content="/content/link_preview.jpg">
 		<meta property="og:url" content="https://www.codeconnective.com">
 
 		<meta name="twitter:title" content="Code Connector">
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta name="twitter:image" content="content/link_preview.jpg">
+		<meta name="twitter:image" content="/content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
-		<link rel="shortcut icon" href="content/favicon.ico">
+		<link rel="shortcut icon" href="/content/favicon.ico">
 
     <title>North Mississippi</title>
 
@@ -36,8 +36,8 @@
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,600,700,900" rel="stylesheet">
 
     <!-- Custom styles -->
-    <link href="css/core.css" rel="stylesheet">
-    <link href="css/secondary.css" rel="stylesheet">
+    <link href="/css/core.css" rel="stylesheet">
+    <link href="/css/secondary.css" rel="stylesheet">
 
   </head>
 
@@ -52,18 +52,18 @@
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
-              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
+              <a class="nav-link" href="/learn" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
+                <a class="dropdown-item" href="/memphis" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="/birmingham" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="/knoxville" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="/montgomery" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="/northmississippi" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -73,13 +73,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
+                <a class="dropdown-item" href="/volunteer" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="/sponsor" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="/assistance" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html" data-target="#">About</a>
+              <a class="nav-link" href="/about" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>
@@ -106,7 +106,7 @@
     <header>
       <div class="overlay"></div>
       <video playsinline="playsinline" autoplay="autoplay" muted="muted" loop="loop">
-        <source src="content/videos/talk2.mp4" type="video/mp4">
+        <source src="/content/videos/talk2.mp4" type="video/mp4">
       </video>
       <div class="container h-100">
         <div class="d-flex h-100 text-center align-items-center">
@@ -125,7 +125,7 @@
           <div class="col-md-12 col-lg-6 pb-4 mb-md-0">
             <div class="card shadow">
               <div class="card-body">
-                <img src="content/images/flyers/CodeTogether-NorthMS.jpg" class="img-fluid rounded mb-3" alt="Code Together North MS flyer">
+                <img src="/content/images/flyers/CodeTogether-NorthMS.jpg" class="img-fluid rounded mb-3" alt="Code Together North MS flyer">
                 <div class="row d-flex justify-content-center">
                   <div class="col-md-4">
                     <a class="btn btn-primary btn-block mb-3 mb-md-0" href="https://www.facebook.com/events/2590520144322867/" target="_blank">Facebook</a>
@@ -186,7 +186,7 @@
         </div>
         <div class="row d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/3.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees posing for group photo (includes bunny ears)">
+            <img src="/content/images/meetups/color/5by7/3.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees posing for group photo (includes bunny ears)">
           </div>
           <div class="col-md-4 ml-lg-4 text-center text-md-left">
             <p class="text-muted">These gatherings aren't classes, so there won't be a teacher, but it is your opportunity to talk with other beginners, mentors, and leaders in your local community. You'll get help jumpstarting the learning process or tackling that programming lesson / personal project you've been working on.</p>
@@ -237,7 +237,7 @@
         </div>
         <div class="row py-5 d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/6.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Two pairs of attendees conversing over code at table">
+            <img src="/content/images/meetups/color/5by7/6.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Two pairs of attendees conversing over code at table">
           </div>
           <div class="col-md-4 ml-md-4 text-center text-md-left">
             <h1 class="text-primary">Rewarding</h1>
@@ -252,12 +252,12 @@
             <p class="text-muted">Having to learn something new on top of full-time work or taking care of kids is tough. With this in mind, we keep things easy to understand and at an undemanding pace.</p>
           </div>
           <div class="col-md-6 order-1 order-md-2">
-            <img src="content/images/meetups/color/5by7/14.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendee examining laptop with mentor">
+            <img src="/content/images/meetups/color/5by7/14.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendee examining laptop with mentor">
           </div>
         </div>
         <div class="row py-5 d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/1.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees having group discussion">
+            <img src="/content/images/meetups/color/5by7/1.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees having group discussion">
           </div>
           <div class="col-md-4 ml-md-4 text-center text-md-left">
             <h1 class="text-primary">Affordable</h1>
@@ -381,7 +381,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.4.1/jquery.easing.min.js" integrity="sha256-H3cjtrm/ztDeuhCN9I4yh4iN2Ybx/y1RM7rMmAesA0k=" crossorigin="anonymous"></script>
     
     <!-- Custom scripts for this template -->
-    <script src="js/custom.js"></script>
+    <script src="/js/custom.js"></script>
 
   </body>
 

--- a/slack.html
+++ b/slack.html
@@ -13,17 +13,17 @@
 
 		<meta property="og:title" content="Code Connector">
 		<meta property="og:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta property="og:image" content="content/link_preview.jpg">
+		<meta property="og:image" content="/content/link_preview.jpg">
 		<meta property="og:url" content="https://www.codeconnective.com">
 
 		<meta name="twitter:title" content="Code Connector">
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta name="twitter:image" content="content/link_preview.jpg">
+		<meta name="twitter:image" content="/content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
-		<link rel="shortcut icon" href="content/favicon.ico">
+		<link rel="shortcut icon" href="/content/favicon.ico">
 
     <title>Slack</title>
 
@@ -36,8 +36,8 @@
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,600,700,900" rel="stylesheet">
 
     <!-- Custom styles -->
-    <link href="css/core.css" rel="stylesheet">
-    <link href="css/secondary.css" rel="stylesheet">
+    <link href="/css/core.css" rel="stylesheet">
+    <link href="/css/secondary.css" rel="stylesheet">
 
   </head>
 
@@ -52,18 +52,18 @@
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
-              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
+              <a class="nav-link" href="/learn" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Memphis</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Birmingham</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Lehigh Valley</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Knoxville</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">North Mississippi</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Memphis</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Birmingham</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Lehigh Valley</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Knoxville</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -73,13 +73,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
+                <a class="dropdown-item" href="/volunteer" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="/sponsor" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="/assistance" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html" data-target="#">About</a>
+              <a class="nav-link" href="/about" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>
@@ -106,7 +106,7 @@
     <header>
       <div class="overlay"></div>
       <video playsinline="playsinline" autoplay="autoplay" muted="muted" loop="loop">
-        <source src="content/videos/talk2.mp4" type="video/mp4">
+        <source src="/content/videos/talk2.mp4" type="video/mp4">
       </video>
       <div class="container h-100">
         <div class="d-flex h-100 text-center align-items-center">
@@ -134,12 +134,12 @@
             <p>Thanks to Slack, no matter the device or system, help is always one click and message away.</p>
           </div>
           <div class="col-md-6 order-1 order-md-2">
-            <img src="content/images/slack/5by7/1.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees having group discussion">
+            <img src="/content/images/slack/5by7/1.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees having group discussion">
           </div>
         </div>
         <div class="row py-5 d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/people/3.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Three attendees seated at a couch check out what the middle attendee is doing on her laptop">
+            <img src="/content/images/people/3.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Three attendees seated at a couch check out what the middle attendee is doing on her laptop">
           </div>
           <div class="col-md-4 ml-md-4 text-center text-md-left">
             <h1 class="text-primary">Open</h1>
@@ -154,7 +154,7 @@
             <p>The overall mission of this platform is to set up a cooperative place that pushes people to succeed. From study buddies to job lead motivation, help is on its way!</p>
           </div>
           <div class="col-md-6 order-1 order-md-2">
-            <img src="content/images/people/2.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Top down view of attendee coding on her laptop">
+            <img src="/content/images/people/2.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Top down view of attendee coding on her laptop">
           </div>
         </div>
         <div class="row text-center justify-content-center my-2 pt-md-5">
@@ -243,7 +243,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.4.1/jquery.easing.min.js" integrity="sha256-H3cjtrm/ztDeuhCN9I4yh4iN2Ybx/y1RM7rMmAesA0k=" crossorigin="anonymous"></script>
     
     <!-- Custom scripts for this template -->
-    <script src="js/custom.js"></script>
+    <script src="/js/custom.js"></script>
 
   </body>
 

--- a/sponsor.html
+++ b/sponsor.html
@@ -13,17 +13,17 @@
 
 		<meta property="og:title" content="Code Connector">
 		<meta property="og:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta property="og:image" content="content/link_preview.jpg">
+		<meta property="og:image" content="/content/link_preview.jpg">
 		<meta property="og:url" content="https://www.codeconnective.com">
 
 		<meta name="twitter:title" content="Code Connector">
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta name="twitter:image" content="content/link_preview.jpg">
+		<meta name="twitter:image" content="/content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
-		<link rel="shortcut icon" href="content/favicon.ico">
+		<link rel="shortcut icon" href="/content/favicon.ico">
 
     <title>Sponsor</title>
 
@@ -36,8 +36,8 @@
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,600,700,900" rel="stylesheet">
 
     <!-- Custom styles -->
-    <link href="css/core.css" rel="stylesheet">
-    <link href="css/secondary.css" rel="stylesheet">
+    <link href="/css/core.css" rel="stylesheet">
+    <link href="/css/secondary.css" rel="stylesheet">
 
   </head>
 
@@ -52,18 +52,18 @@
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
-              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
+              <a class="nav-link" href="/learn" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Memphis</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Birmingham</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Lehigh Valley</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Knoxville</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">North Mississippi</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Memphis</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Birmingham</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Lehigh Valley</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Knoxville</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -73,13 +73,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
+                <a class="dropdown-item" href="/volunteer" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="/sponsor" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="/assistance" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html" data-target="#">About</a>
+              <a class="nav-link" href="/about" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>
@@ -106,7 +106,7 @@
     <header>
       <div class="overlay"></div>
       <video playsinline="playsinline" autoplay="autoplay" muted="muted" loop="loop">
-        <source src="content/videos/workshop2.mp4" type="video/mp4">
+        <source src="/content/videos/workshop2.mp4" type="video/mp4">
       </video>
       <div class="container h-100">
         <div class="d-flex h-100 text-center align-items-center">
@@ -221,12 +221,12 @@
             </ol>
           </div>
           <div class="col-md-7 order-1 order-md-2">
-            <img src="content/images/meetups/color/5by7/19a.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees seated around two tables having discussions">
+            <img src="/content/images/meetups/color/5by7/19a.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees seated around two tables having discussions">
           </div>
         </div>
         <div class="row py-5 d-flex align-items-center justify-content-center">
           <div class="col-md-7">
-            <img src="content/images/meetups/color/5by7/9.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Mostly standing attendees led in discussion by mentor">
+            <img src="/content/images/meetups/color/5by7/9.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Mostly standing attendees led in discussion by mentor">
           </div>
           <div class="col-md-5 pl-md-5 text-center text-md-left">
             <h2 class="text-primary">Access</h2>
@@ -283,44 +283,44 @@
         <div class="row mb-lg-5 d-flex justify-content-center">
           <div class="col-3 col-sm-2 col-lg-1 pb-4 pb-lg-0 mx-lg-4 d-flex align-items-center">
             <a href="https://knoxdevs.com" target="blank">
-              <img class="img-fluid" src="content/images/sponsors/knoxdevs-dark.png" alt="KnoxDevs">
+              <img class="img-fluid" src="/content/images/sponsors/knoxdevs-dark.png" alt="KnoxDevs">
             </a>
           </div>
           <div class="col-8 col-md-7 col-lg-3 pb-4 pb-lg-0 mx-lg-4 d-flex align-items-center">
             <a href="http://www.epicenter.com" target="blank">
-              <img class="img-fluid" src="content/images/sponsors/epicenter-dark.png" alt="Epicenter Memphis">
+              <img class="img-fluid" src="/content/images/sponsors/epicenter-dark.png" alt="Epicenter Memphis">
             </a>
           </div>
           <div class="col-6 col-md-4 col-lg-2 pb-4 pb-lg-0 mx-lg-4 d-flex align-items-center">
             <a href="https://www.meetup.com/base205/" target="blank">
-              <img class="img-fluid" src="content/images/sponsors/base-dark.png" alt="BASE (Birmingham Alabama Software Enthusiasts">
+              <img class="img-fluid" src="/content/images/sponsors/base-dark.png" alt="BASE (Birmingham Alabama Software Enthusiasts">
             </a>
           </div>
           <div class="col-3 col-md-2 col-lg-1 pb-4 pb-lg-0 mx-lg-4 d-flex align-items-center">
             <a href="http://www.memphistechnology.org/" target="blank">
-              <img class="img-fluid" src="content/images/sponsors/memtech-dark.png" alt="Memphis Technology Foundation">
+              <img class="img-fluid" src="/content/images/sponsors/memtech-dark.png" alt="Memphis Technology Foundation">
             </a>
           </div>
         </div>
         <div class="row mb-lg-4 d-flex justify-content-center">
           <div class="col-7 col-lg-3 pb-4 pb-lg-0 mx-lg-4 d-flex align-items-center">
             <a href="https://innovationdepot.org/" target="blank">
-              <img class="img-fluid" src="content/images/sponsors/innovationdepot-dark.png" alt="Innovation Depot">
+              <img class="img-fluid" src="/content/images/sponsors/innovationdepot-dark.png" alt="Innovation Depot">
             </a>
           </div>
           <div class="col-3 col-md-2 col-lg-1 pb-4 pb-lg-0 mx-lg-2 d-flex align-items-center">
             <a href="https://www.learnbuildteach.com/" target="blank">
-              <img class="img-fluid" src="content/images/sponsors/lbt-dark.png" alt="Learn Build Teach">
+              <img class="img-fluid" src="/content/images/sponsors/lbt-dark.png" alt="Learn Build Teach">
             </a>
           </div>
           <div class="col-6 col-md-4 col-lg-2 pb-4 pb-lg-0 mx-lg-4 d-flex align-items-center">
             <a href="http://knoxec.com/" target="blank">
-              <img class="img-fluid" src="content/images/sponsors/kec-dark.png" alt="Knoxville Entrepreneur Center">
+              <img class="img-fluid" src="/content/images/sponsors/kec-dark.png" alt="Knoxville Entrepreneur Center">
             </a>
           </div>
           <div class="col-5 col-md-4 col-lg-2 pb-4 pb-lg-0 mx-lg-4 d-flex align-items-center">
             <a href="https://coworkingnight.org/" target="blank">
-              <img class="img-fluid" src="content/images/sponsors/coworkingnight-dark.png" alt="CoWorking Night">
+              <img class="img-fluid" src="/content/images/sponsors/coworkingnight-dark.png" alt="CoWorking Night">
             </a>
           </div>
         </div>
@@ -405,7 +405,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.4.1/jquery.easing.min.js" integrity="sha256-H3cjtrm/ztDeuhCN9I4yh4iN2Ybx/y1RM7rMmAesA0k=" crossorigin="anonymous"></script>
     
     <!-- Custom scripts for this template -->
-    <script src="js/custom.js"></script>
+    <script src="/js/custom.js"></script>
 
   </body>
 

--- a/thankyou.html
+++ b/thankyou.html
@@ -13,17 +13,17 @@
 
 		<meta property="og:title" content="Code Connector">
 		<meta property="og:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta property="og:image" content="content/link_preview.jpg">
+		<meta property="og:image" content="/content/link_preview.jpg">
 		<meta property="og:url" content="https://www.codeconnective.com">
 
 		<meta name="twitter:title" content="Code Connector">
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta name="twitter:image" content="content/link_preview.jpg">
+		<meta name="twitter:image" content="/content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
-		<link rel="shortcut icon" href="content/favicon.ico">
+		<link rel="shortcut icon" href="/content/favicon.ico">
 
     <title>Code Connector</title>
 
@@ -36,8 +36,8 @@
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,600,700,900" rel="stylesheet">
 
     <!-- Custom styles -->
-    <link href="css/core.css" rel="stylesheet">
-    <link href="css/success.css" rel="stylesheet">
+    <link href="/css/core.css" rel="stylesheet">
+    <link href="/css/success.css" rel="stylesheet">
 
   </head>
 
@@ -52,18 +52,18 @@
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
-              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
+              <a class="nav-link" href="/learn" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="memphis.html" data-target="#">Memphis</a>
-                <a class="dropdown-item" href="birmingham.html" data-target="#">Birmingham</a>
-                <a class="dropdown-item" href="knoxville.html" data-target="#">Knoxville</a>
-                <a class="dropdown-item" href="montgomery.html" data-target="#">Montgomery</a>
-                <a class="dropdown-item" href="northmississippi.html" data-target="#">North Mississippi</a>
+                <a class="dropdown-item" href="/memphis" data-target="#">Memphis</a>
+                <a class="dropdown-item" href="/birmingham" data-target="#">Birmingham</a>
+                <a class="dropdown-item" href="/knoxville" data-target="#">Knoxville</a>
+                <a class="dropdown-item" href="/montgomery" data-target="#">Montgomery</a>
+                <a class="dropdown-item" href="/northmississippi" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -73,13 +73,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
+                <a class="dropdown-item" href="/volunteer" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="/sponsor" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="/assistance" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html" data-target="#">About</a>
+              <a class="nav-link" href="/about" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>
@@ -106,7 +106,7 @@
     <header>
       <div class="overlay"></div>
       <video playsinline="playsinline" autoplay="autoplay" muted="muted" loop="loop">
-        <source src="content/videos/workshop1.mp4" type="video/mp4">
+        <source src="/content/videos/workshop1.mp4" type="video/mp4">
       </video>
       <div class="container h-100">
         <div class="row"></div>
@@ -129,7 +129,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.4.1/jquery.easing.min.js" integrity="sha256-H3cjtrm/ztDeuhCN9I4yh4iN2Ybx/y1RM7rMmAesA0k=" crossorigin="anonymous"></script>
 
     <!-- Custom scripts for this template -->
-    <script src="js/custom.js"></script>
+    <script src="/js/custom.js"></script>
 
   </body>
 

--- a/volunteer.html
+++ b/volunteer.html
@@ -13,17 +13,17 @@
 
 		<meta property="og:title" content="Code Connector">
 		<meta property="og:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta property="og:image" content="content/link_preview.jpg">
+		<meta property="og:image" content="/content/link_preview.jpg">
 		<meta property="og:url" content="https://www.codeconnective.com">
 
 		<meta name="twitter:title" content="Code Connector">
 		<meta name="twitter:description" content="Connecting adults with free coding + career resources, workshops & experiences">
-		<meta name="twitter:image" content="content/link_preview.jpg">
+		<meta name="twitter:image" content="/content/link_preview.jpg">
 		<meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@codeconnector_">
     
     <!-- Favicon -->
-		<link rel="shortcut icon" href="content/favicon.ico">
+		<link rel="shortcut icon" href="/content/favicon.ico">
 
     <title>Volunteer</title>
 
@@ -36,8 +36,8 @@
     <link href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,400i,600,700,900" rel="stylesheet">
 
     <!-- Custom styles -->
-    <link href="css/core.css" rel="stylesheet">
-    <link href="css/secondary.css" rel="stylesheet">
+    <link href="/css/core.css" rel="stylesheet">
+    <link href="/css/secondary.css" rel="stylesheet">
 
   </head>
 
@@ -52,18 +52,18 @@
         <div class="collapse navbar-collapse" id="navbarResponsive">
           <ul class="navbar-nav ml-auto">
             <li class="nav-item">
-              <a class="nav-link" href="learn.html" data-target="#">Learn</a>
+              <a class="nav-link" href="/learn" data-target="#">Learn</a>
             </li>
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Events
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Memphis</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Birmingham</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Lehigh Valley</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">Knoxville</a>
-                <a class="dropdown-item disabled" href="learn.html" data-target="#">North Mississippi</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Memphis</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Birmingham</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Lehigh Valley</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">Knoxville</a>
+                <a class="dropdown-item disabled" href="/learn" data-target="#">North Mississippi</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item" data-toggle="modal" data-target="#meetupRequest" href="#">Start a meetup</a>
               </div>
@@ -73,13 +73,13 @@
                 Support
               </a>
               <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                <a class="dropdown-item" href="volunteer.html" data-target="#">Get involved</a>
-                <a class="dropdown-item" href="sponsor.html" data-target="#">Through sponsorship</a>
-                <a class="dropdown-item" href="assistance.html" data-target="#">Receive meetup assistance</a>
+                <a class="dropdown-item" href="/volunteer" data-target="#">Get involved</a>
+                <a class="dropdown-item" href="/sponsor" data-target="#">Through sponsorship</a>
+                <a class="dropdown-item" href="/assistance" data-target="#">Receive meetup assistance</a>
               </div>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="about.html" data-target="#">About</a>
+              <a class="nav-link" href="/about" data-target="#">About</a>
             </li>
             <li class="nav-item">
               <a class="nav-link js-scroll-trigger" href="#contact">Contact</a>
@@ -106,7 +106,7 @@
     <header>
       <div class="overlay"></div>
       <video playsinline="playsinline" autoplay="autoplay" muted="muted" loop="loop">
-        <source src="content/videos/workshop2.mp4" type="video/mp4">
+        <source src="/content/videos/workshop2.mp4" type="video/mp4">
       </video>
       <div class="container h-100">
         <div class="d-flex h-100 text-center align-items-center">
@@ -189,12 +189,12 @@
               <p class="text-muted">Whether it's through leadership or through assistance, we're always looking for people to step up and be there to help people meet in their local community.</p>
             </div>
             <div class="col-md-6 order-1 order-md-2">
-              <img src="content/images/meetups/color/5by7/2.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees gathered around table watching presentation">
+              <img src="/content/images/meetups/color/5by7/2.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees gathered around table watching presentation">
             </div>
         </div>
         <div class="row py-5 d-flex align-items-center justify-content-center">
           <div class="col-md-6">
-            <img src="content/images/meetups/color/5by7/17.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees in class session">
+            <img src="/content/images/meetups/color/5by7/17.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Attendees in class session">
           </div>
           <div class="col-md-4 ml-md-4 text-center text-md-left">
             <h1 class="text-primary">Classes</h1>
@@ -207,7 +207,7 @@
             <p class="text-muted">Even you're not able to attend meetups in your local, your drive to help and wisedom could help someone in need through our online chat community.</p>
           </div>
           <div class="col-md-6 order-1 order-md-2">
-            <img src="content/images/slack/5by7/2.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Stock photo of Slack being used on laptop and phone">
+            <img src="/content/images/slack/5by7/2.jpg" class="img-fluid mb-4 mb-md-0 rounded" alt="Stock photo of Slack being used on laptop and phone">
           </div>
         </div>
       </div>
@@ -306,7 +306,7 @@
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-easing/1.4.1/jquery.easing.min.js" integrity="sha256-H3cjtrm/ztDeuhCN9I4yh4iN2Ybx/y1RM7rMmAesA0k=" crossorigin="anonymous"></script>
     
     <!-- Custom scripts for this template -->
-    <script src="js/custom.js"></script>
+    <script src="/js/custom.js"></script>
 
   </body>
 


### PR DESCRIPTION
Since all links are relative, the html files assume they are in the root. This leaves no room for html files to be moved to provide folders for subspaces. 11ty assumes each file is the index of a folder with that name. This change is required to fix asset paths with 11ty.