### PR TITLE
Add in missing Raleway font

### DIFF
--- a/assistance.html
+++ b/assistance.html
@@ -32,6 +32,7 @@
 
     <!-- Custom fonts for this template -->
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.6.3/css/all.css" integrity="sha384-UHRtZLI+pbxtHCWp1t77Bi1L4ZtiqrqD80Kn4Z8NTSRyMA2Fd33n5dQ8lWUE00s/" crossorigin="anonymous">
+    <link href="https://fonts.googleapis.com/css?family=Raleway:900" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,600,900&display=swap" rel="stylesheet">
 
     <!-- Custom styles -->


### PR DESCRIPTION
CSS references this font for the page heading title, but the font is rarely
available on users' browsers and must have it imported like it is on other
pages.